### PR TITLE
add the expert profile, two top models at the highest effort

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "revmux",
       "source": "./",
       "description": "Run a supervised multi-agent code review or triage a filed issue with parallel claude and codex subprocesses, and act on what comes back",
-      "version": "0.3.3",
+      "version": "0.4.0",
       "author": {
         "name": "umputun"
       }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "revmux",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "Run a supervised multi-agent code review or triage a filed issue with parallel claude and codex subprocesses, and act on what comes back",
   "author": {
     "name": "umputun",

--- a/.claude-plugin/skills/revmux/SKILL.md
+++ b/.claude-plugin/skills/revmux/SKILL.md
@@ -269,7 +269,14 @@ scale numbers are what Step 4's one-line announcement is built from.
 | `claude-only` | the same four lens splits, all on claude | no codex available |
 | `codex-only` | the same four lens splits on codex, and synthesis and verify with them | no claude available |
 | `grill-me` | `bugs+impl` and `architecture+quality`, each once on claude and once on codex, all reading against the change | the user wants it torn apart |
+| `expert` | two agents at the highest effort, codex `gpt-5.6-sol` and claude `fable`, each carrying all eight lenses | a plan, or a change nobody wants to get wrong. Slow and expensive; pick it when he says so, not by default |
 | `triage` | `facts` (grounding + precedent), `thesis`, `antithesis`, `cost` on codex | a filed item rather than a diff; needs `--no-synthesis --verify-group-by source`, `references/triage.md` |
+
+**Never choose `expert` on your own.** It is two agents at `xhigh` each applying every lens, so it costs
+several times what `comprehensive` does, and no property of the subject justifies reaching for it — not a
+plan, not a large diff, not a risky one. Pick it only when the user asked for it in words, and say that
+is why. Every other profile reviews whatever it is pointed at, a plan included; `expert`'s severity bar
+is simply written so a proposal reads as naturally as a diff.
 
 **A profile word is not a profile name.** Map whatever the user said onto the profiles `revmux config`
 reports, matching the name first and the `description` second. revmux rejects an unknown `--profile` at
@@ -284,6 +291,7 @@ fails the run.
 | claude only, no codex, skip codex | `claude-only` |
 | codex only, no claude, codex alone | `codex-only` |
 | grill me, tear it apart, be brutal, no mercy, adversarial | `grill-me` |
+| expert, best models, highest effort, spare no expense, use sol and fable | `expert` — and only on words like these, never inferred from the subject |
 | triage this, is this worth doing, should we accept this, should I close this | `triage`, and the subject is a filed item rather than a diff — `references/triage.md`, which owns the flags it needs |
 
 Examples, not the list. Match on intent — breadth wants `comprehensive`, speed wants `focused`, a merge

--- a/.claude-plugin/skills/revmux/references/invocation.md
+++ b/.claude-plugin/skills/revmux/references/invocation.md
@@ -218,6 +218,7 @@ will not read, and an unwritable `./.revmux/` under `revmux init`.
 | `claude-only` | `bugs+impl`, `arch+quality`, `docs+tests`, `adversarial` — all on claude | codex is unavailable or unwanted |
 | `codex-only` | the same four splits on codex, synthesis and verify included — no claude anywhere | claude is unavailable or unwanted |
 | `grill-me` | `bugs+impl` and `architecture+quality`, each run once on claude and once on codex, every agent reading against the change | the user asked to be grilled; corroboration between two vendors on one lens pair is the point |
+| `expert` | two agents at the highest effort — codex `gpt-5.6-sol:xhigh` and claude `fable:xhigh` — each carrying all eight lenses, both stages on fable | a plan, or a change nobody wants to get wrong. Both agents read everything, so agreement between them is real corroboration rather than two halves of one review |
 | `triage` | `facts` (grounding + precedent), `thesis`, `antithesis` on claude, plus `cost` on codex | the subject is a filed item rather than a diff — an issue, a proposal, a discussion |
 
 `--profile <name>`. The default is `comprehensive` and is itself a config knob.
@@ -225,6 +226,16 @@ will not read, and an unwritable `./.revmux/` under `revmux init`.
 `triage` is the one shipped profile that needs flags beside it: `--no-synthesis`, because every argument
 a panel produces is single-source and the drop rule eats them, and `--verify-group-by source`, so each
 panelist's case is verified apart from the case answering it. `references/triage.md` is the procedure.
+
+`expert` needs no extra flags, and **is never selected on the caller's own judgment**. Two agents at
+`xhigh` each applying every lens costs several times what `comprehensive` does, and nothing about the
+subject earns it — not a plan, not a large diff, not a risky one. It runs when the user asked for it in
+words, and not otherwise.
+
+What its body does differently is only calibration: the severity bar rates what goes wrong if the thing
+is built and run as written rather than what goes wrong at runtime, and the what-not-to-report block
+distinguishes reviewing a change from reviewing a proposal. Every profile reviews whatever `scope.md`
+points at, a plan included; `expert` is the one whose wording does not assume a diff.
 
 ## Lenses
 
@@ -542,7 +553,7 @@ revmux drives the model CLIs as subprocesses, so both must already be installed 
 
 - `claude` — every lens agent and both model stages run on it by default
 - `codex` — needed when a profile, a roster entry or a stage names it in its `model:`. `claude-only`
-  needs claude alone and `codex-only` needs codex alone; the other five shipped profiles need both.
+  needs claude alone and `codex-only` needs codex alone; the other six shipped profiles need both.
   `preflight.sh <profile>` answers it for the profile that will actually run
 
 `ANTHROPIC_API_KEY` is stripped from the child environment by default so `claude` uses interactive

--- a/.claude/rules/prompts.md
+++ b/.claude/rules/prompts.md
@@ -13,6 +13,7 @@ and get the same review, and change a timeout without touching a prompt.
 
 ```
 prompts/profiles/comprehensive.md   focused.md   final.md   claude-only.md   codex-only.md   grill-me.md
+prompts/profiles/expert.md
 prompts/profiles/triage.md
 prompts/synthesis.md   prompts/verify.md
 lenses/bugs.md  impl.md  architecture.md  quality.md  docs.md  tests.md  comments.md  adversarial.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -411,7 +411,7 @@ Stamping happens in `find`, not synthesis, or `--no-synthesis` runs carry invent
   One that changes what a stage resolves to needs `revmux config` as a fifth site: `profileInfo.Stages`
   reports the resolution rather than the override, so a key it does not carry is invisible to the caller
   choosing the profile.
-- A change to the `model:` grammar is `app/prompt/runner.go` plus every authored file that uses it: seven
+- A change to the `model:` grammar is `app/prompt/runner.go` plus every authored file that uses it: eight
   shipped profiles, both stage files, the README front-matter section, `.claude/rules/prompts.md`, and the
   fixtures in `app/prompt` and `app/pipeline` tests. The parsed form reaches `AgentSpec`, `Stage` and
   `RunnerSpec` as three separate fields, so nothing downstream of the parser changes — which is what keeps
@@ -466,38 +466,43 @@ Stamping happens in `find`, not synthesis, or `--no-synthesis` runs carry invent
   be literal. `TestDefaults_SeverityContract` is **not** — it derives the full profiles from
   `ProfileNames()` so a new one is guarded without being listed, which is what a contract check has to do
   and what a literal list there silently stopped doing.
-  It names two exemptions, and each is a profile whose bar is deliberately not the shared one: `final`
-  reports two severities rather than three, and `triage` rates how much a point bears on a decision rather
-  than what goes wrong at runtime.
-  Both are pinned by their own assertions instead, so an exemption removes a profile from the equality
+  It names three exemptions, and each is a profile whose bar is deliberately not the shared one: `final`
+  reports two severities rather than three, `triage` rates how much a point bears on a decision rather
+  than what goes wrong at runtime, and `expert` reviews a plan as readily as a diff so it rates what goes
+  wrong if the thing is built and run as written.
+  Each is pinned by its own assertions instead, so an exemption removes a profile from the equality
   check and never from the test.
-  **An exemption is for a bar that is meant to differ, never for one that has drifted** — a third name
-  added to that list to make a failing run pass is the mechanism the derived-from-`ProfileNames()` design
-  exists to prevent.
+  **An exemption is for a bar that is meant to differ, never for one that has drifted** — a name added to
+  that list to make a failing run pass is the mechanism the derived-from-`ProfileNames()` design exists to
+  prevent, and the three that are there each name the review shape their bar is written for.
 - **The severity bar is duplicated in every profile body** and nothing composes it from one place:
   `comprehensive`, `codex-only`, `claude-only`, `focused` and `grill-me` carry a byte-identical
-  `## Severity bar` section, `final` carries a two-severity variant of the same text, and `triage` carries
+  `## Severity bar` section, `final` carries a two-severity variant of the same text, `triage` carries
   a bar that is not a variant of it at all — its severities rate how much a point bears on the decision,
-  because it reads a filed item and there is no runtime for anything to go wrong at.
-  A change to what a severity means is seven edits, and the five identical copies must stay identical —
+  because it reads a filed item and there is no runtime for anything to go wrong at — and `expert` carries
+  a third shape, rating what goes wrong if the thing is built and run as written, because what it reviews
+  may be a plan rather than a change.
+  A change to what a severity means is eight edits, and the five identical copies must stay identical —
   two profiles disagreeing about what `major` is means the same defect gates one review shape and not
   another, which reads as the model being inconsistent rather than the prompts being out of step.
-  A code-review wording change stops at the five: propagating it into `triage` is what the separate bar
-  exists to prevent.
+  A code-review wording change stops at the five: propagating it into `triage` or `expert` is what the
+  separate bars exist to prevent.
   `.claude/rules/prompts.md` calls the body "the shared preamble and severity bar"; shared across the
   agents of one run, not across profiles.
-  **`## What not to report` is the second such block**, byte-identical in six of the seven, and it is the
+  **`## What not to report` is the second such block**, byte-identical in six of the eight, and it is the
   one a finder consults before writing anything down — so a rule added to one profile and not the others
   makes the same finding reportable under one review shape and suppressed under another.
-  `triage` is the exception and carries its own, since the shipped copy is written about diffs and defers
-  to the linters and tests a review runs after; a panel reading an issue is doing neither.
-  `TestDefaults_WhatNotToReportContract` exempts it by name and asserts its block separately, exactly as
-  the severity contract does — the equality check over the other six is not weakened to accommodate it.
+  `triage` and `expert` are the exceptions and carry their own, since the shipped copy is written about
+  diffs and defers to the linters and tests a review runs after: a panel reading an issue is doing
+  neither, and `expert` may be reading a plan where nothing ran and no line was touched.
+  `TestDefaults_WhatNotToReportContract` exempts both by name and asserts their blocks separately, exactly
+  as the severity contract does — the equality check over the other six is not weakened to accommodate
+  either.
   **`grill-me`'s `## Stance` section is the third**, and it duplicates a *lens* rather than another
   profile: roughly half of `lenses/adversarial.md` is copied into it verbatim, including the "Work the
   seams" bullets and the two paragraphs on titling the mechanism.
   The copy exists because that profile puts the adversarial stance on all four agents, where it is
-  preamble rather than a lens — but the five profiles that name `adversarial` compose that file itself, so an
+  preamble rather than a lens — but the six profiles that name `adversarial` compose that file itself, so an
   edit there leaves `grill-me` stale and the two shapes then instruct agents differently about severity
   inflation in the profile whose whole premise is pushing against that bar.
   What is deliberately **not** copied stays not copied: `adversarial.md` tells its agent not to repeat

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Override the location with `BINDIR` when `/usr/local/bin` is not writable — `m
 revmux drives the model CLIs as subprocesses, so whichever ones your profile names must already be
 installed and authenticated. Which those are is a property of the profile, not a fixed pair:
 
-- `comprehensive`, `focused`, `final`, `grill-me`, `triage` — both, a claude roster plus codex
+- `comprehensive`, `focused`, `final`, `grill-me`, `triage`, `expert` — both, a claude roster plus codex
 - `claude-only` — claude alone
 - `codex-only` — codex alone
 
@@ -351,6 +351,7 @@ so an invocation that stays outside never picks up the reviewed repository's own
 │   │   ├── claude-only.md
 │   │   ├── codex-only.md
 │   │   ├── grill-me.md
+│   │   ├── expert.md
 │   │   └── triage.md
 │   ├── synthesis.md
 │   └── verify.md
@@ -452,6 +453,16 @@ Shipped profiles:
 | `codex-only` | the same four lens splits on codex, and synthesis and verify with them — no claude anywhere |
 | `grill-me` | `bugs+impl` and `architecture+quality`, each run once on claude and once on codex, every agent reading against the change |
 | `triage` | `facts`, `thesis`, `antithesis` on claude plus `cost` on codex — a panel over a filed item rather than a diff, and it wants `--no-synthesis` |
+| `expert` | two agents at the highest effort — codex `gpt-5.6-sol` and claude `fable` — each carrying all eight lenses, and both stages on fable |
+
+`expert` is for when the answer matters more than the wall clock, and it is expensive enough that it is
+worth asking for deliberately rather than reaching for by default — the shipped skill will not select it
+unless you say so. Both agents read everything rather than splitting the lenses between them, so where
+the two models independently agree, the cross-source boost measures genuine corroboration rather than two
+halves of one review. Its severity bar rates what goes wrong if the thing is built and run as written,
+and its what-not-to-report block distinguishes reviewing a change from reviewing a proposal, so a plan
+reads as naturally as a diff — any profile can be pointed at one, this is the one whose wording does not
+assume otherwise.
 
 `triage` reviews an issue, a proposal or a discussion instead of a change. Its severities rate how much a
 point bears on the decision rather than what goes wrong at runtime, and it returns arguments for a

--- a/app/initcmd_test.go
+++ b/app/initcmd_test.go
@@ -78,7 +78,7 @@ func TestRun_init(t *testing.T) {
 		for _, org := range set.Provenance() {
 			assert.Equal(t, prompt.LayerProject, org.Layer, "%s fell back, so the tree is not self-sufficient", org.Path)
 		}
-		assert.Equal(t, []string{"claude-only", "codex-only", "comprehensive", "final", "focused", "grill-me", "triage"}, set.ProfileNames())
+		assert.Equal(t, []string{"claude-only", "codex-only", "comprehensive", "expert", "final", "focused", "grill-me", "triage"}, set.ProfileNames())
 		for _, l := range set.Lenses() {
 			assert.NotEmpty(t, l.Description, "lens %s lost its front matter on the way to disk", l.Name)
 		}

--- a/app/main_test.go
+++ b/app/main_test.go
@@ -158,7 +158,7 @@ func TestRun_config(t *testing.T) {
 				assert.NotEmpty(t, a.Color, "agent %s reports no color, so the palette assignment is invisible", a.Name)
 			}
 		}
-		assert.Equal(t, []string{"claude-only", "codex-only", "comprehensive", "final", "focused", "grill-me", "triage"}, names)
+		assert.Equal(t, []string{"claude-only", "codex-only", "comprehensive", "expert", "final", "focused", "grill-me", "triage"}, names)
 
 		set, err := prompt.Load(prompt.LoadOpts{})
 		require.NoError(t, err)

--- a/app/prompt/defaults/prompts/profiles/expert.md
+++ b/app/prompt/defaults/prompts/profiles/expert.md
@@ -1,0 +1,91 @@
+---
+description: two agents at the highest effort, codex sol and claude fable, each carrying all eight lenses — for a plan, or a change nobody wants to get wrong
+model: claude/fable:xhigh
+agents:
+  - {name: sol,   lenses: [bugs, impl, architecture, quality, docs, tests, comments, adversarial], model: codex/gpt-5.6-sol:xhigh, color: cyan}
+  - {name: fable, lenses: [bugs, impl, architecture, quality, docs, tests, comments, adversarial], color: magenta}
+---
+You are one of two reviewers. The other carries the same lenses as you, on a different model. You
+never see their findings and must not guess at them — report what you find yourself. Where the two of
+you independently land on the same thing, that agreement is the strongest signal in the report, and it
+only means something because neither of you saw the other.
+
+This review is **read-only**. You may read files and run read-only commands such as `git diff`,
+`git log` and `rg`. Do not modify, delete, move, stage or commit anything, and do not write a file
+through a shell redirect. Report what you find; changing it is the caller's job, never yours.
+Do not run tests, builds or the linter.
+
+You are running at the highest effort available because this one is worth getting right. Read the
+surrounding code rather than only what changed, and follow a claim to the place it would actually
+break before you write it down.
+
+## What is under review
+
+**It may be a change, or it may be a document proposing one** — a plan, a design note, a proposal.
+`{{SCOPE}}` says which, and it is the first thing to read.
+
+- a **change**: `{{SCOPE}}` carries the command that produces the diff. Run it yourself.
+- a **proposal**: `{{SCOPE}}` names the document. Read it, then read the code it would change, and
+  judge it against what is actually there rather than against what it says is there. A plan whose
+  premise about the existing code is wrong is the most expensive kind of defect to find late.
+
+## Where the context lives
+
+Every item below is a **path**, not the text it names. Read the file or directory before you start.
+
+- `{{SCOPE}}` — what is under review, and how to reach it.
+- `{{GOAL}}` — what the change or proposal is trying to achieve.
+- `{{PROFILE}}` — the project's own conventions and standards. Where they disagree with your general
+  taste, they win.
+- `{{CONTEXT}}` — a directory of supporting material: ticket text, design notes, spec excerpts.
+- `{{WORKDIR}}` — run every command from here.
+
+Any of these may read `none provided`. That is not an error and not something to work around: the
+caller supplied nothing for it, so calibrate severity generically to that extent rather than
+inventing the missing context.
+
+## Severity bar
+
+What is under review may be a change, or a document proposing one. Rate by what goes wrong if it is
+built and run as written.
+
+- **critical** — the approach cannot work, or it loses data, corrupts state or opens a security hole
+  when built as described.
+- **major** — wrong behavior, a broken contract a caller executes against, or a decision that has to
+  be undone later at real cost.
+- **minor** — a real defect with contained impact.
+
+A defect in prose that nothing executes against — a comment, a README, a passing remark in a design
+note — is **minor**. Report it; never promote it because the claim is badly wrong. A document a
+machine, an agent or an implementer executes against as a contract is not that: rate it by what its
+consumer does wrong, and a plan under review is exactly such a document.
+
+Anything you cannot place on that bar is not a finding. Style preferences, hypotheticals and
+"consider maybe" notes are noise.
+
+## Reporting
+
+Apply every lens you carry, in full, and tag each finding with the lens that raised it.
+
+- Point at a specific location — a file and line in code, a named section in a document. A finding
+  with no location cannot be verified.
+- State the failure concretely: the input or state, and what goes wrong because of it.
+- Report the confidence you actually have, not the confidence that keeps the finding alive.
+- Say when a problem is pre-existing rather than introduced by what is under review.
+- Do not report one problem twice under two lenses. Report it once and name both lenses on it.
+
+## What not to report
+
+Silence beats a finding the reader has to disprove. Do not report:
+
+- reviewing a change: a defect on a line it did not touch, unless the change is what makes it reachable
+- reviewing a change: anything a linter, compiler or type checker catches — all of them ran and passed
+- a lint or vet rule the code silences deliberately, with the directive visible
+- a missing test, missing doc or general-quality observation the project's own rules do not ask for
+- a nitpick a senior engineer would not raise
+- a behaviour change, or a design decision, that is plainly the point of what is under review
+- reviewing a proposal: a detail it deliberately leaves to implementation, unless leaving it open is
+  itself the defect
+
+Pre-existing problems are the one exception: report them, and say so, so the reader can weigh them
+separately from what this introduces.

--- a/app/prompt/defaults_test.go
+++ b/app/prompt/defaults_test.go
@@ -65,8 +65,8 @@ func TestDefaults_EveryProfileResolvesItsRoster(t *testing.T) {
 	set, err := Load(LoadOpts{})
 	require.NoError(t, err)
 	known := set.LensNames()
-	require.Len(t, set.ProfileNames(), 7,
-		"the shipped set is comprehensive, focused, final, claude-only, codex-only, grill-me and triage")
+	require.Len(t, set.ProfileNames(), 8,
+		"the shipped set is comprehensive, focused, final, claude-only, codex-only, grill-me, triage and expert")
 
 	for _, name := range set.ProfileNames() {
 		p, err := set.Profile(name)
@@ -234,12 +234,13 @@ func TestDefaults_SeverityContract(t *testing.T) {
 	require.NoError(t, err)
 
 	// derived from the shipped set rather than listed, so a new full profile is guarded without being
-	// named here. final reports two severities and triage rates decision weight rather than runtime
-	// damage; both are asserted separately below.
+	// named here. final reports two severities, triage rates decision weight rather than runtime damage,
+	// and expert reviews a plan as well as a diff so it rates what goes wrong if the thing is built;
+	// all three are asserted separately below.
 	var expected string
 	compared := 0
 	for _, name := range set.ProfileNames() {
-		if name == "final" || name == "triage" {
+		if name == "final" || name == "triage" || name == "expert" {
 			continue
 		}
 		p, profileErr := set.Profile(name)
@@ -274,6 +275,15 @@ func TestDefaults_SeverityContract(t *testing.T) {
 	assert.Contains(t, triageText, "**critical** — decisive on its own")
 	assert.NotContains(t, triageText, "Severity is what goes wrong when the code runs",
 		"a panel arguing about a filed item has no code running to go wrong")
+
+	expert, err := set.Profile("expert")
+	require.NoError(t, err)
+	expertText := strings.Join(strings.Fields(expert.Body), " ")
+	assert.Contains(t, expertText, "Rate by what goes wrong if it is built and run as written")
+	assert.Contains(t, expertText, "the approach cannot work")
+	assert.Contains(t, expertText, "a plan under review is exactly such a document")
+	assert.NotContains(t, expertText, "Severity is what goes wrong when the code runs",
+		"a plan has no runtime, and expert reviews one as readily as a diff")
 }
 
 func TestDefaults_EveryLensIsComposedBySomeProfile(t *testing.T) {
@@ -402,8 +412,10 @@ func TestDefaults_WhatNotToReportContract(t *testing.T) {
 	var expected string
 	compared := 0
 	for _, name := range set.ProfileNames() {
-		if name == "triage" {
-			continue // it suppresses arguments about a filed item, not findings about a diff
+		if name == "triage" || name == "expert" {
+			// triage suppresses arguments about a filed item rather than findings about a diff, and
+			// expert reviews a plan too, where no linter ran and no line was touched
+			continue
 		}
 		p, profileErr := set.Profile(name)
 		require.NoError(t, profileErr)
@@ -433,4 +445,13 @@ func TestDefaults_WhatNotToReportContract(t *testing.T) {
 	assert.Contains(t, section, "a cost, a duplicate or a risk you did not actually check")
 	assert.NotContains(t, section, "linter",
 		"a triage panel is not told to defer to tools that ran before a review it is not doing")
+
+	expert, err := set.Profile("expert")
+	require.NoError(t, err)
+	start = strings.Index(expert.Body, "## What not to report")
+	require.NotEqual(t, -1, start, "expert has no what-not-to-report section")
+	section = strings.TrimSpace(expert.Body[start:])
+	assert.Contains(t, section, "reviewing a change: a defect on a line it did not touch")
+	assert.Contains(t, section, "reviewing a proposal: a detail it deliberately leaves to implementation")
+	assert.Contains(t, section, "Pre-existing problems are the one exception")
 }

--- a/app/prompt/prompt_test.go
+++ b/app/prompt/prompt_test.go
@@ -25,7 +25,7 @@ func TestLoad_EmbeddedDefaults(t *testing.T) {
 	set, err := Load(LoadOpts{})
 	require.NoError(t, err)
 
-	assert.Equal(t, []string{"claude-only", "codex-only", "comprehensive", "final", "focused", "grill-me", "triage"}, set.ProfileNames())
+	assert.Equal(t, []string{"claude-only", "codex-only", "comprehensive", "expert", "final", "focused", "grill-me", "triage"}, set.ProfileNames())
 	for _, l := range set.Lenses() {
 		assert.NotEmpty(t, l.Description, "lens %s", l.Name)
 	}
@@ -45,7 +45,7 @@ func TestLoad_EmbeddedDefaults(t *testing.T) {
 func TestLoad_MissingDirsAreAbsentLayers(t *testing.T) {
 	set, err := Load(LoadOpts{ProjectDir: filepath.Join(t.TempDir(), "nope"), UserDir: filepath.Join(t.TempDir(), "also-nope")})
 	require.NoError(t, err)
-	assert.Equal(t, []string{"claude-only", "codex-only", "comprehensive", "final", "focused", "grill-me", "triage"}, set.ProfileNames())
+	assert.Equal(t, []string{"claude-only", "codex-only", "comprehensive", "expert", "final", "focused", "grill-me", "triage"}, set.ProfileNames())
 
 	for _, o := range set.Provenance() {
 		assert.Equal(t, LayerEmbedded, o.Layer, o.Path)

--- a/plugins/codex/skills/revmux/SKILL.md
+++ b/plugins/codex/skills/revmux/SKILL.md
@@ -307,7 +307,14 @@ scale numbers are what Step 4's one-line announcement is built from.
 | `claude-only` | the same four lens splits, all on claude | no codex available |
 | `codex-only` | the same four lens splits on codex, and synthesis and verify with them | no claude available |
 | `grill-me` | `bugs+impl` and `architecture+quality`, each once on claude and once on codex, all reading against the change | the user wants it torn apart |
+| `expert` | two agents at the highest effort, codex `gpt-5.6-sol` and claude `fable`, each carrying all eight lenses | a plan, or a change nobody wants to get wrong. Slow and expensive; pick it when he says so, not by default |
 | `triage` | `facts` (grounding + precedent), `thesis`, `antithesis`, `cost` on codex | a filed item rather than a diff; needs `--no-synthesis --verify-group-by source`, `references/triage.md` |
+
+**Never choose `expert` on your own.** It is two agents at `xhigh` each applying every lens, so it costs
+several times what `comprehensive` does, and no property of the subject justifies reaching for it — not a
+plan, not a large diff, not a risky one. Pick it only when the user asked for it in words, and say that
+is why. Every other profile reviews whatever it is pointed at, a plan included; `expert`'s severity bar
+is simply written so a proposal reads as naturally as a diff.
 
 **A profile word is not a profile name.** Map whatever the user said onto the profiles `revmux config`
 reports, matching the name first and the `description` second. revmux rejects an unknown `--profile` at
@@ -322,6 +329,7 @@ fails the run.
 | claude only, no codex, skip codex | `claude-only` |
 | codex only, no claude, codex alone | `codex-only` |
 | grill me, tear it apart, be brutal, no mercy, adversarial | `grill-me` |
+| expert, best models, highest effort, spare no expense, use sol and fable | `expert` — and only on words like these, never inferred from the subject |
 | triage this, is this worth doing, should we accept this, should I close this | `triage`, and the subject is a filed item rather than a diff — `references/triage.md`, which owns the flags it needs |
 
 Examples, not the list. Match on intent — breadth wants `comprehensive`, speed wants `focused`, a merge

--- a/plugins/codex/skills/revmux/references/invocation.md
+++ b/plugins/codex/skills/revmux/references/invocation.md
@@ -218,6 +218,7 @@ will not read, and an unwritable `./.revmux/` under `revmux init`.
 | `claude-only` | `bugs+impl`, `arch+quality`, `docs+tests`, `adversarial` — all on claude | codex is unavailable or unwanted |
 | `codex-only` | the same four splits on codex, synthesis and verify included — no claude anywhere | claude is unavailable or unwanted |
 | `grill-me` | `bugs+impl` and `architecture+quality`, each run once on claude and once on codex, every agent reading against the change | the user asked to be grilled; corroboration between two vendors on one lens pair is the point |
+| `expert` | two agents at the highest effort — codex `gpt-5.6-sol:xhigh` and claude `fable:xhigh` — each carrying all eight lenses, both stages on fable | a plan, or a change nobody wants to get wrong. Both agents read everything, so agreement between them is real corroboration rather than two halves of one review |
 | `triage` | `facts` (grounding + precedent), `thesis`, `antithesis` on claude, plus `cost` on codex | the subject is a filed item rather than a diff — an issue, a proposal, a discussion |
 
 `--profile <name>`. The default is `comprehensive` and is itself a config knob.
@@ -225,6 +226,16 @@ will not read, and an unwritable `./.revmux/` under `revmux init`.
 `triage` is the one shipped profile that needs flags beside it: `--no-synthesis`, because every argument
 a panel produces is single-source and the drop rule eats them, and `--verify-group-by source`, so each
 panelist's case is verified apart from the case answering it. `references/triage.md` is the procedure.
+
+`expert` needs no extra flags, and **is never selected on the caller's own judgment**. Two agents at
+`xhigh` each applying every lens costs several times what `comprehensive` does, and nothing about the
+subject earns it — not a plan, not a large diff, not a risky one. It runs when the user asked for it in
+words, and not otherwise.
+
+What its body does differently is only calibration: the severity bar rates what goes wrong if the thing
+is built and run as written rather than what goes wrong at runtime, and the what-not-to-report block
+distinguishes reviewing a change from reviewing a proposal. Every profile reviews whatever `scope.md`
+points at, a plan included; `expert` is the one whose wording does not assume a diff.
 
 ## Lenses
 
@@ -542,7 +553,7 @@ revmux drives the model CLIs as subprocesses, so both must already be installed 
 
 - `claude` — every lens agent and both model stages run on it by default
 - `codex` — needed when a profile, a roster entry or a stage names it in its `model:`. `claude-only`
-  needs claude alone and `codex-only` needs codex alone; the other five shipped profiles need both.
+  needs claude alone and `codex-only` needs codex alone; the other six shipped profiles need both.
   `preflight.sh <profile>` answers it for the profile that will actually run
 
 `ANTHROPIC_API_KEY` is stripped from the child environment by default so `claude` uses interactive


### PR DESCRIPTION
adds `expert`, a profile for the cases where the answer matters more than the wall clock.

two agents instead of the usual three or four, and both carry all eight lenses rather than splitting them between them: `sol` on `codex/gpt-5.6-sol:xhigh` and `fable` on `claude/fable:xhigh`, with the profile-level `model:` putting synthesis and verify on fable too. The full overlap is deliberate. With two agents a lens split makes every finding single-source, so the drop rule eats the weak ones and the cross-source boost never fires; two independent reads of the same ground turn agreement into real corroboration instead.

its severity bar rates what goes wrong if the thing is built and run as written rather than what goes wrong at runtime, and its `## What not to report` block separates reviewing a change from reviewing a proposal, so the wording never assumes a diff. Any profile can be pointed at a plan; this is the one that reads like it expects to be. That makes it a third exemption in `TestDefaults_SeverityContract` and a second in `TestDefaults_WhatNotToReportContract`, each pinned by its own assertions so the exemption drops it from the equality check and not from the test.

the shipped skill is told never to select it on its own. Nothing about a subject earns two agents at xhigh, not a plan, not a large diff, not a risky one, so it runs only when asked for by name and the trigger table carries no word that could be inferred from the subject.

the rest is the sweep a new profile needs: four literal inventories in the tests, the README profile table and executor bullet and prompt tree, the layout block in `.claude/rules/prompts.md`, four count-bearing bullets in `CLAUDE.md`, and four sites across both skill trees. Plugin and marketplace go 0.3.3 to 0.4.0.

verified with `revmux config`, which resolves `sol` to codex/gpt-5.6-sol at xhigh, `fable` to claude/fable at xhigh, and both stages to fable.
