### PR TITLE
align go comments with the comment rules, fix treewriter error path

### DIFF
--- a/app/archive/archive_test.go
+++ b/app/archive/archive_test.go
@@ -448,11 +448,11 @@ func TestNew_liveRound(t *testing.T) {
 	})
 }
 
+// New looks at the round entry and then opens it, and those are two operations: a symlink planted in
+// between is followed by os.Root whenever it lands back inside the task, which is exactly the
+// round -> earlier round case the look exists to refuse. These reproduce that window by opening the
+// handle on the swapped entry first and only then running the check that has to catch it.
 func TestCheckHandle(t *testing.T) {
-	// New looks at the round entry and then opens it, and those are two operations: a symlink planted in
-	// between is followed by os.Root whenever it lands back inside the task, which is exactly the
-	// round -> earlier round case the look exists to refuse. These reproduce that window by opening the
-	// handle on the swapped entry first and only then running the check that has to catch it.
 	t.Run("a symlink swapped in before the open is caught after it", func(t *testing.T) {
 		taskPath := t.TempDir()
 		require.NoError(t, os.MkdirAll(filepath.Join(taskPath, "01-initial", inputDir), 0o750))

--- a/app/archive/cleanup_test.go
+++ b/app/archive/cleanup_test.go
@@ -75,6 +75,8 @@ func TestCleanup(t *testing.T) {
 	})
 }
 
+// the idle check releases each round's lock as it moves on, so it must leave none behind on a task it
+// refused: a lock still held would block the next review from claiming that round.
 func TestCleanup_refusals(t *testing.T) {
 	t.Run("no task named", func(t *testing.T) {
 		_, err := Cleanup(CleanupQuery{TasksDir: t.TempDir()})
@@ -123,7 +125,6 @@ func TestCleanup_refusals(t *testing.T) {
 		assert.DirExists(t, round, "nothing is removed while a review is writing into it")
 	})
 
-	// the check releases as it goes, so it must not leave a lock behind that blocks the next review
 	t.Run("the check leaves no lock behind on a task it refused", func(t *testing.T) {
 		root := t.TempDir()
 		round := filepath.Join(root, "alpha", "01-initial")
@@ -165,9 +166,9 @@ func TestCleanup_refusals(t *testing.T) {
 	})
 }
 
+// task.List accepts a task directory that is a relative symlink to a sibling, and every read path follows
+// it — so cleanup reaches one and must not report the alias as the history it points at.
 func TestCleanup_alias(t *testing.T) {
-	// task.List accepts a task directory that is a relative symlink to a sibling, and every read path
-	// follows it — so cleanup reaches one and must not report the alias as the history it points at
 	t.Run("a symlinked task is refused, naming what it points at", func(t *testing.T) {
 		root := t.TempDir()
 		recordRound(t, filepath.Join(root, "pr-123", "01-initial"), map[string]finding.Report{
@@ -205,9 +206,9 @@ func TestCleanup_alias(t *testing.T) {
 	})
 }
 
+// a task holding one unreadable directory must still be removable, or the user is pushed back to the
+// rm -rf this command exists to replace.
 func TestCleanup_unreadableEntry(t *testing.T) {
-	// a task holding one unreadable directory must still be removable, or the user is pushed back to the
-	// rm -rf this command exists to replace
 	t.Run("a task with an unreadable directory is still removed, its size a floor", func(t *testing.T) {
 		if os.Geteuid() == 0 {
 			t.Skip("root traverses a 0000 directory regardless of its mode")

--- a/app/archive/collect_test.go
+++ b/app/archive/collect_test.go
@@ -99,6 +99,8 @@ func TestRoundReader_readFullRound(t *testing.T) {
 	})
 }
 
+// --no-synthesis --no-verify writes neither snapshot, so stages/1-found.json is the last word and nothing
+// filtered anything: survived equals raised because no stage ran, not because the agent earned it.
 func TestRoundReader_read(t *testing.T) {
 	t.Run("an agent whose findings all get dropped survives nothing", func(t *testing.T) {
 		dir := t.TempDir()
@@ -140,8 +142,6 @@ func TestRoundReader_read(t *testing.T) {
 			"a stage nothing wrote is not a transition that happened")
 	})
 
-	// --no-synthesis --no-verify writes neither snapshot, so stages/1-found.json is the last word and
-	// nothing filtered anything: survived equals raised because no stage ran, not because the agent earned it
 	t.Run("a run that skipped both stages counts stage 1 as its own survivors", func(t *testing.T) {
 		dir := t.TempDir()
 		writeArtifact(t, dir, foundFile, finding.Report{
@@ -279,6 +279,8 @@ func TestRoundReader_ambiguousLenses(t *testing.T) {
 	}
 }
 
+// the synthesis stage retries under the same event kind, naming itself as the agent. Counted blind it
+// becomes a source no roster contains, reported beside the agents that really ran.
 func TestRoundReader_readEvents(t *testing.T) {
 	t.Run("retries are counted per agent", func(t *testing.T) {
 		dir := t.TempDir()
@@ -300,8 +302,6 @@ func TestRoundReader_readEvents(t *testing.T) {
 			"the kind decides, not a text that happens to name one")
 	})
 
-	// the synthesis stage retries under the same event kind, naming itself as the agent. Counted blind it
-	// becomes a source no roster contains, reported beside the agents that really ran
 	t.Run("a stage retry is not an agent", func(t *testing.T) {
 		dir := t.TempDir()
 		writeArtifact(t, dir, foundFile, finding.Report{
@@ -891,9 +891,9 @@ func TestCollectStats_disk(t *testing.T) {
 	})
 }
 
+// the regression this pins: dirSize walking the whole tree made one unreadable directory under one task
+// fatal for the corpus, so `revmux stats` reported nothing about the other tasks at all.
 func TestCollectStats_unreadableEntry(t *testing.T) {
-	// the regression this pins: dirSize walking the whole tree made one unreadable directory under one
-	// task fatal for the corpus, so `revmux stats` reported nothing about the other tasks at all
 	t.Run("one unreadable directory does not discard every other task's numbers", func(t *testing.T) {
 		if os.Geteuid() == 0 {
 			t.Skip("root traverses a 0000 directory regardless of its mode")
@@ -922,9 +922,9 @@ func TestCollectStats_unreadableEntry(t *testing.T) {
 	})
 }
 
+// the fold is what `revmux stats` prints: it reports the task entry and the totals, never one round's own
+// tally, so a field computed per round and not folded here is zero everywhere it is read.
 func TestTaskStats_addStages(t *testing.T) {
-	// the fold is what `revmux stats` prints: it reports the task entry and the totals, never one
-	// round's own tally, so a field computed per round and not folded here is zero everywhere it is read
 	t.Run("every field folds, not only in and out", func(t *testing.T) {
 		var got taskStats
 		got.addStages([]stageFlow{{Name: "verify", In: 10, Out: 9, Reclassified: 2, Refined: 4}})

--- a/app/archive/size_test.go
+++ b/app/archive/size_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// one unreadable round under one task must not discard every other task's numbers, and must not be
+// reported as a task occupying nothing either: the total is a floor and says which entry it is missing.
 func TestDirSize(t *testing.T) {
 	t.Run("regular files under the tree are summed, at every depth", func(t *testing.T) {
 		dir := t.TempDir()
@@ -29,8 +31,6 @@ func TestDirSize(t *testing.T) {
 		assert.Empty(t, unread, "an absent dir is not even a skip")
 	})
 
-	// one unreadable round under one task must not discard every other task's numbers, and must not be
-	// reported as a task occupying nothing either: the total is a floor and says which entry it is missing
 	t.Run("an unreadable entry is skipped and named, and what is readable is still summed", func(t *testing.T) {
 		if os.Geteuid() == 0 {
 			t.Skip("root traverses a 0000 directory regardless of its mode")
@@ -90,6 +90,7 @@ func TestMB(t *testing.T) {
 	}
 }
 
+// the rounds argument is task.Rounds' order, which is lexical rather than chronological.
 func TestLastRun(t *testing.T) {
 	write := func(t *testing.T, dir, round, body string) {
 		t.Helper()
@@ -105,7 +106,6 @@ func TestLastRun(t *testing.T) {
 		assert.Equal(t, "2026-07-31", lastRun(dir, []string{"01-initial", "02-after-fix"}))
 	})
 
-	// the rounds argument is task.Rounds' order, which is lexical rather than chronological
 	t.Run("order of the rounds argument does not decide it", func(t *testing.T) {
 		dir := t.TempDir()
 		write(t, dir, "01-initial", `{"finished_at":"2026-07-31T09:00:00Z"}`)

--- a/app/archive/stats_test.go
+++ b/app/archive/stats_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/umputun/revmux/app/finding"
 )
 
+// the totals fold both size and date across tasks — only the id and the description are per-task, since no
+// one description covers a corpus.
 func TestCorpus_JSON(t *testing.T) {
 	c := Corpus{
 		Tasks: []taskStats{{
@@ -60,8 +62,6 @@ func TestCorpus_JSON(t *testing.T) {
 		assert.Equal(t, map[string]any{"confirmed": 1.0, "unverified": 2.0}, lens["verdicts"])
 	})
 
-	// the totals fold both size and date across tasks — only the id and the description are per-task,
-	// since no one description covers a corpus
 	t.Run("totals carry size and date but no id or description", func(t *testing.T) {
 		totals := got["totals"].(map[string]any)
 		assert.Equal(t, []string{"agents", "last_run", "lenses", "rounds", "size_mb", "skipped", "stages"},

--- a/app/cleanupcmd_test.go
+++ b/app/cleanupcmd_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/umputun/revmux/app/task"
 )
 
+// the reason no --task is declared on the subcommand: the one a caller passed would be the one nothing
+// read, and that removes nothing while reporting success.
 func TestParseArgs_cleanupSubcommand(t *testing.T) {
 	t.Run("the command word selects the removal and nothing else", func(t *testing.T) {
 		isolate(t)
@@ -32,8 +34,6 @@ func TestParseArgs_cleanupSubcommand(t *testing.T) {
 		assert.False(t, o.showCleanup)
 	})
 
-	// the reason no --task is declared on the subcommand: the one a caller passed would be the one nothing
-	// read, and here that removes nothing while reporting success
 	t.Run("--task lands in one field whichever side of the command word it is on", func(t *testing.T) {
 		isolate(t)
 		before, err := parseArgs([]string{"--task", "pr-1", "cleanup"})

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -585,6 +585,9 @@ func TestOptions_promptSetUnknownProfile(t *testing.T) {
 	assert.Contains(t, err.Error(), "resolve profile")
 }
 
+// the config was the last leaf on the init path still written by name. os.ReadFile reports a dangling link
+// as an absent file and os.WriteFile then creates its target, so the two symlink cases are the write
+// escaping ./.revmux/ entirely and an existing file outside it being truncated.
 func TestOptions_initConfig(t *testing.T) {
 	dir := isolate(t)
 	path := filepath.Join(dir, projectDirName, configFileName)
@@ -631,9 +634,6 @@ func TestOptions_initConfig(t *testing.T) {
 		assert.Contains(t, out.String(), "customized")
 	})
 
-	// the config was the last leaf on the init path still written by name. os.ReadFile reports a
-	// dangling link as an absent file and os.WriteFile then creates its target, so the two cases below
-	// are the write escaping ./.revmux/ entirely and an existing file outside it being truncated.
 	t.Run("a dangling symlink at the config is refused rather than written through", func(t *testing.T) {
 		outside := filepath.Join(t.TempDir(), "elsewhere.ini")
 		require.NoError(t, os.Remove(path))

--- a/app/executor/rollout_test.go
+++ b/app/executor/rollout_test.go
@@ -160,6 +160,9 @@ func TestCodex_readRollout(t *testing.T) {
 	})
 }
 
+// codex prints the session id before it creates the rollout, so the file is not there for the first
+// glob. Giving up at that one look silenced a real codex source for a whole review while its rollout
+// filled beside it, which is why the tail keeps looking rather than returning.
 func TestCodex_tailRollout(t *testing.T) {
 	t.Run("an unknown session reports nothing and stops when the run does", func(t *testing.T) {
 		c := NewCodex(nil, Opts{})
@@ -179,9 +182,6 @@ func TestCodex_tailRollout(t *testing.T) {
 		assert.Empty(t, sink.all(), "a session with no rollout reports nothing at all")
 	})
 
-	// codex prints the session id before it creates the rollout, so the file is not there for the first
-	// glob. Giving up at that one look silenced a real codex source for a whole review while its rollout
-	// filled beside it, which is why the tail keeps looking rather than returning.
 	t.Run("a rollout created after the tail starts is still picked up, from its first record", func(t *testing.T) {
 		home := t.TempDir()
 		t.Setenv("CODEX_HOME", home)

--- a/app/inputsnapshot.go
+++ b/app/inputsnapshot.go
@@ -60,7 +60,7 @@ func (s *inputSnapshotter) load(rc reviewContext) []ui.InputDocument {
 
 // inputPath preserves an optional file's existence for the display snapshot without changing the
 // prompt-facing resolved value, where a missing file and an empty file both intentionally become the
-// placeholder. All callers are snapshotter methods, so this filesystem decision stays on the owner.
+// placeholder.
 func (*inputSnapshotter) inputPath(rc reviewContext, name, resolved string) string {
 	if rc.InputDir == "" {
 		return resolved

--- a/app/introspect_test.go
+++ b/app/introspect_test.go
@@ -173,6 +173,8 @@ func TestOptions_catalogProfileRunner(t *testing.T) {
 	assert.Empty(t, wire.Runner.Name, "the base runner names no stage")
 }
 
+// an unreadable tasks root reported as no tasks at all is the advice that mints a duplicate id, the same
+// failure an unreported meta_error produces one level down.
 func TestOptions_paths(t *testing.T) {
 	root := t.TempDir()
 	for _, name := range []string{"pr-1", "pr-2"} {
@@ -205,8 +207,6 @@ func TestOptions_paths(t *testing.T) {
 			"a workdir that will not resolve is a review that dies later, not a resolved path")
 	})
 
-	// an unreadable tasks root reported as no tasks at all is the advice that mints a duplicate id, the
-	// same failure an unreported meta_error produces one level down
 	t.Run("an unreadable tasks root is reported, never as an empty one", func(t *testing.T) {
 		if os.Geteuid() == 0 {
 			t.Skip("root reads a directory with no permissions")

--- a/app/main_test.go
+++ b/app/main_test.go
@@ -797,6 +797,8 @@ func TestRunOpts_render(t *testing.T) {
 	})
 }
 
+// the reader may close the browser before or after the report reaches it; either way package main is the
+// one writer, which is what these assert.
 func TestRun_reportWrittenOnce(t *testing.T) {
 	base := func(t *testing.T) options {
 		t.Helper()
@@ -809,8 +811,6 @@ func TestRun_reportWrittenOnce(t *testing.T) {
 	found := executor.Result{StructuredOutput: json.RawMessage(
 		`{"findings":[{"file":"a.go","line":1,"severity":"major","confidence":90,"title":"unchecked error"}]}`)}
 
-	// the reader may close the browser before or after the report reaches it; either way package
-	// main is the one writer, which is what these assert
 	t.Run("under the tui", func(t *testing.T) {
 		r := newRunOpts(t, base(t))
 		r.result = found

--- a/app/newcmd_test.go
+++ b/app/newcmd_test.go
@@ -42,6 +42,8 @@ func TestParseArgs_newSubcommand(t *testing.T) {
 	})
 }
 
+// the whole point of the subcommand: what a caller writes to the paths it was handed is what a review of
+// that same round reads, with no path composed anywhere in between.
 func TestRun_new(t *testing.T) {
 	scaffold := func(t *testing.T, o options) (task.Paths, *runHarness) {
 		t.Helper()
@@ -81,8 +83,6 @@ func TestRun_new(t *testing.T) {
 		assert.Equal(t, p.TaskDir, rc.TaskDir, "the task directory, not the round, is what history enumerates")
 	})
 
-	// the whole point of the subcommand: what a caller writes to the paths it was handed is what a review
-	// of that same round reads, with no path composed anywhere in between
 	t.Run("a review of the scaffolded round reads its input and archives into it", func(t *testing.T) {
 		root := t.TempDir()
 		p, _ := scaffold(t, options{TasksDir: root, Task: "pr-123", Run: "01-initial"})

--- a/app/pipeline/artifacts_test.go
+++ b/app/pipeline/artifacts_test.go
@@ -18,6 +18,10 @@ import (
 	"github.com/umputun/revmux/app/task"
 )
 
+// in the archive-path subtest both sides of the comparison are the constants' own runtime values,
+// so it cannot see a literal that happens to spell one of them correctly — what it catches is an
+// archived name under none of the seven roots, and a root nothing wrote to. The literal values are
+// pinned in app/archive/archive_test.go
 func TestPipeline_Run_artifacts(t *testing.T) {
 	t.Run("every composed prompt is archived byte for byte", func(t *testing.T) {
 		h, seen := artifactHarness(t)
@@ -205,9 +209,6 @@ func TestPipeline_Run_artifacts(t *testing.T) {
 		assert.NotEmpty(t, kinds[EventStage], "stage transitions are decisions too")
 	})
 
-	// both sides of the comparison are the constants' own runtime values, so this cannot see a literal
-	// that happens to spell one of them correctly — what it catches is an archived name under none of the
-	// seven roots, and a root nothing wrote to. The literal values are pinned in app/archive/archive_test.go
 	t.Run("every archive path lands under an app/task constant", func(t *testing.T) {
 		h, _ := artifactHarness(t)
 

--- a/app/pipeline/synthesize_test.go
+++ b/app/pipeline/synthesize_test.go
@@ -576,6 +576,8 @@ func synthJSON(items ...string) json.RawMessage {
 	return json.RawMessage(`{"findings":[` + strings.Join(items, ",") + `],"open_questions":[],"pre_existing":[]}`)
 }
 
+// a merge claiming every input is the ordinary case, and the empty result is what suppresses the
+// dropped event entirely — an archive line saying nothing was dropped on every clean round is noise
 func TestSynthesizer_unclaimed(t *testing.T) {
 	s := &synthesizer{}
 	inputs := map[string]finding.Finding{
@@ -591,8 +593,6 @@ func TestSynthesizer_unclaimed(t *testing.T) {
 			"ordered by id, so an archived event does not reorder between two runs of one round")
 	})
 
-	// a merge claiming everything is the ordinary case, and the empty result is what suppresses the
-	// event entirely — an archive line saying nothing was dropped on every clean round is noise
 	t.Run("a merge that claimed every input drops nothing", func(t *testing.T) {
 		claimed := map[string]bool{"bugs+impl-1": true, "bugs+impl-2": true, "codex-1": true}
 		assert.Empty(t, s.unclaimed(inputs, claimed))

--- a/app/pipeline/verify_test.go
+++ b/app/pipeline/verify_test.go
@@ -264,6 +264,8 @@ func TestVerifier_run_groupIsolation(t *testing.T) {
 	}
 }
 
+// the codex path has no --json-schema, so a refined verdict can name a severity outside the enum:
+// letting it through replaces a schema-checked value with one nothing validated
 func TestVerifier_run_verdicts(t *testing.T) {
 	t.Run("every verdict routes its finding", func(t *testing.T) {
 		h := newHarness(t)
@@ -313,8 +315,6 @@ func TestVerifier_run_verdicts(t *testing.T) {
 		assert.Equal(t, []string{"bugs"}, got.Sources, "verification does not touch attribution")
 	})
 
-	// the codex path has no --json-schema, so a refined verdict can name a severity outside the enum.
-	// letting it through replaces a schema-checked value with one nothing validated
 	t.Run("a refined verdict with an unknown severity keeps the original", func(t *testing.T) {
 		h := newHarness(t)
 		h.cfg.NewRunner = verdictRunner(map[string]string{

--- a/app/progress.go
+++ b/app/progress.go
@@ -250,7 +250,5 @@ func (pr *progress) paint(agent string) string {
 			return spec.Paint(agent)
 		}
 	}
-	// a stage or verify group is not in the roster, and it gets its color from the same place the TUI
-	// takes it, so one agent is one color whichever renderer a reviewer is watching
 	return prompt.DerivedSpec(agent).Paint(agent)
 }

--- a/app/prompt/roster.go
+++ b/app/prompt/roster.go
@@ -50,7 +50,7 @@ var colorPalette = []string{"cyan", "magenta", "green", "yellow", "blue", "red",
 
 var hexColor = regexp.MustCompile(`^#[0-9a-fA-F]{6}$`)
 
-// Each kind of prompt file declares its own front-matter shape rather than sharing one, because unknown
+// each kind of prompt file declares its own front-matter shape rather than sharing one, because unknown
 // keys are rejected and one shared shape accepts every key in every file. Every one of them selects its
 // runner through a single `model:` string — see runner.go — and there is no `executor:` or `effort:` key.
 

--- a/app/prompt/roster_test.go
+++ b/app/prompt/roster_test.go
@@ -457,9 +457,9 @@ func TestVocabularies(t *testing.T) {
 	assert.Equal(t, "claude", Executors()[0])
 }
 
+// a stage or verify group is not in the roster but still has to be told apart in the log. Both
+// renderers call this, so what it must guarantee is that they cannot disagree.
 func TestDerivedSpec(t *testing.T) {
-	// a stage or verify group is not in the roster but still has to be told apart in the log. Both
-	// renderers call this, so what it must guarantee is that they cannot disagree.
 	t.Run("the same name always resolves to the same color", func(t *testing.T) {
 		for _, name := range []string{"synthesis", "verify ui", "verify executor"} {
 			first := DerivedSpec(name)

--- a/app/prompt/runner_test.go
+++ b/app/prompt/runner_test.go
@@ -56,6 +56,7 @@ func TestParseRunner_Errors(t *testing.T) {
 	}
 }
 
+// a model belongs to a binary, so inheriting one across binaries is how `opus` reaches codex
 func TestRunner_or(t *testing.T) {
 	base := Runner{Executor: "claude", Model: "opus", Effort: "high"}
 
@@ -69,7 +70,6 @@ func TestRunner_or(t *testing.T) {
 			Runner{Executor: "claude", Model: "sonnet"}.or(base))
 	})
 
-	// a model belongs to a binary, so inheriting one across binaries is how `opus` reaches codex
 	t.Run("a different binary never inherits the model", func(t *testing.T) {
 		assert.Equal(t, Runner{Executor: "codex", Effort: "high"}, Runner{Executor: "codex"}.or(base))
 		assert.Equal(t, Runner{Executor: "codex", Model: "gpt-5.6-sol", Effort: "low"},

--- a/app/statscmd_test.go
+++ b/app/statscmd_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/umputun/revmux/app/task"
 )
 
+// the reason no --task is declared on the subcommand: a second one would make the two invocations below
+// fill different fields, and the one the caller passed would be the one nothing read.
 func TestParseArgs_statsSubcommand(t *testing.T) {
 	t.Run("the command word selects the corpus reading", func(t *testing.T) {
 		isolate(t)
@@ -32,8 +34,6 @@ func TestParseArgs_statsSubcommand(t *testing.T) {
 		assert.False(t, o.showStats)
 	})
 
-	// the reason no --task is declared on the subcommand: a second one would make these two invocations
-	// fill different fields, and the one the caller passed would be the one nothing read
 	t.Run("--task lands in one field whichever side of the command word it is on", func(t *testing.T) {
 		isolate(t)
 		before, err := parseArgs([]string{"--task", "pr-1", "stats"})
@@ -55,6 +55,8 @@ func TestParseArgs_statsSubcommand(t *testing.T) {
 	})
 }
 
+// ambiguous and the verdict map are the two per-lens numbers a suggestion has to quote, so they have to
+// survive the trip through the payload rather than only through the archive types.
 func TestRun_stats(t *testing.T) {
 	corpusOf := func(t *testing.T, o options) (statsDoc, *runHarness) {
 		t.Helper()
@@ -91,8 +93,6 @@ func TestRun_stats(t *testing.T) {
 		assert.Empty(t, doc.Tasks[0].Skipped, "every round here decodes, and the field is present rather than absent")
 	})
 
-	// ambiguous and the verdict map are the two per-lens numbers a suggestion has to quote, so they have to
-	// survive the trip through the payload rather than only through the archive types
 	t.Run("per-lens ambiguity and verdicts reach stdout", func(t *testing.T) {
 		isolate(t)
 		root := t.TempDir()

--- a/app/task/task_test.go
+++ b/app/task/task_test.go
@@ -665,6 +665,9 @@ func TestRounds(t *testing.T) {
 	})
 }
 
+// metaFile is a task's own metadata one level down, so the tasks root reserves no name at all: a directory
+// called task.md there is a task a review really runs under, and omitting it from the enumeration would
+// hide a task revmux new can still scaffold.
 func TestList(t *testing.T) {
 	root := t.TempDir()
 	for _, name := range []string{"pr-1", "pr-2"} {
@@ -677,9 +680,6 @@ func TestList(t *testing.T) {
 	assert.Equal(t, []string{"pr-1", "pr-2"}, got,
 		"only directories are tasks, and the ids come back in a stable order")
 
-	// metaFile is a task's own metadata one level down, so the tasks root reserves no name at all: a
-	// directory called task.md there is a task a review really runs under, and omitting it from the
-	// enumeration would hide a task revmux new can still scaffold
 	t.Run("no name is reserved at the tasks root", func(t *testing.T) {
 		dir := t.TempDir()
 		require.NoError(t, os.MkdirAll(filepath.Join(dir, metaFile), 0o750))

--- a/app/treewriter.go
+++ b/app/treewriter.go
@@ -45,10 +45,11 @@ func (w *treeWriter) close() error {
 // between the look and the write.
 func (w *treeWriter) write(relPath string, data []byte) (bool, error) {
 	if dir := path.Dir(relPath); dir != "." {
-		// an escaping link occupying a directory name reports ErrExist here and is named by the entry
-		// check below, which says where the path leaves the destination rather than that it is taken
+		// an escaping link occupying a directory name is refused here rather than at the entry check
+		// below, so the failure names the entry: the directory alone does not say which file was
+		// refused. A link landing back inside the destination is followed and reports ErrExist.
 		if err := w.root.MkdirAll(dir, 0o750); err != nil && !errors.Is(err, fs.ErrExist) {
-			return false, fmt.Errorf("create %s: %w", w.dest(dir), err)
+			return false, fmt.Errorf("create %s: %w", w.dest(relPath), err)
 		}
 	}
 

--- a/app/ui/agentpane_test.go
+++ b/app/ui/agentpane_test.go
@@ -45,10 +45,9 @@ func TestModel_focusedAt(t *testing.T) {
 	assert.Nil(t, m.focusedAt(3))
 }
 
+// both behaviors are exercised past their no-op form: short plain text at the default width exercises
+// neither the markdown rendering nor the wrapping, and passes unchanged with both removed.
 func TestModel_agentLines_rendersAndWraps(t *testing.T) {
-	// **both behaviors, exercised past their no-op form.** The pane gained markdown rendering and
-	// wrapping, and a case feeding short plain text at the default width exercises neither — it passes
-	// unchanged with both removed, which is what the previous assertion did.
 	m := feed(t, New(ModelConfig{Roster: roster()}), tea.WindowSizeMsg{Width: 60, Height: 24})
 	m = feed(t, m,
 		event(pipeline.EventAgentActivity, "bugs+impl",

--- a/app/ui/findings_test.go
+++ b/app/ui/findings_test.go
@@ -58,7 +58,7 @@ func listedReport() finding.Report {
 func browsed(t *testing.T, rep finding.Report) Model {
 	t.Helper()
 	m := New(ModelConfig{Roster: roster()})
-	// same five-line pane the scroll tests use, so the cursor-follow expectations stay in screenfuls
+	// same five-line pane the scroll tests use, so the scroll expectations stay in screenfuls
 	m = feed(t, m, tea.WindowSizeMsg{Width: 100, Height: len(roster()) + chromeLines + 5},
 		CompletedMsg{Report: rep})
 	return m
@@ -143,9 +143,9 @@ func TestModel_findingsPane(t *testing.T) {
 	})
 }
 
+// the browser has no cursor: it renders the report and the pane's own scrolling reads it, which is the
+// same scrolling every other pane has.
 func TestFindingsState_scroll(t *testing.T) {
-	// the browser has no cursor: it renders the report and the pane's own scrolling reads it, which is
-	// the same scrolling every other pane has
 	t.Run("the arrow and vi keys scroll it like any other pane", func(t *testing.T) {
 		m := browsed(t, report())
 		require.Positive(t, m.maxScroll(), "the report is longer than the pane, or there is nothing to test")

--- a/app/ui/mdrender_test.go
+++ b/app/ui/mdrender_test.go
@@ -563,6 +563,9 @@ func TestMDRenderer_renderDownsamplesToProfile(t *testing.T) {
 	}
 }
 
+// the nested-list case pins expansion running ahead of the parser: at the terminal's eight-column stop
+// a list nested under a tab lands past the four-space code-block threshold CommonMark measures against,
+// and the nested item comes back as literal "- nested" text with its own bullet gone.
 func TestMDRenderer_renderExpandsTabs(t *testing.T) {
 	// a tab is one cell to lipgloss and up to eight to the terminal, so an unexpanded row is measured
 	// short and drawn wide — straight past the edge of the pane. Models write Go tab-indented.
@@ -580,9 +583,6 @@ func TestMDRenderer_renderExpandsTabs(t *testing.T) {
 		})
 	}
 
-	// regression: expansion runs ahead of the parser, so at the terminal's eight-column stop a list
-	// nested under a tab lands past the four-space code-block threshold CommonMark measures against,
-	// and the nested item comes back as literal "- nested" text with its own bullet gone
 	t.Run("a tab-indented nested list keeps its nesting", func(t *testing.T) {
 		r := testMDRenderer()
 		out := plainMD(r.render("- first\n\t- nested\n", 40))

--- a/app/ui/style.go
+++ b/app/ui/style.go
@@ -8,7 +8,7 @@ import (
 	"github.com/muesli/termenv"
 )
 
-// The palette. Adaptive rather than fixed: a reviewer running a light terminal gets legible muted
+// the palette. Adaptive rather than fixed: a reviewer running a light terminal gets legible muted
 // text instead of the near-invisible grey a dark-only palette produces.
 var (
 	colAccent = lipgloss.AdaptiveColor{Light: "25", Dark: "39"}   // titles, the focused tab

--- a/app/ui/style_test.go
+++ b/app/ui/style_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// lipgloss decides whether to emit color by profiling a writer, and its default renderer profiles
+// os.Stdout. Under `revmux > file` stdout is a pipe while the reader watches a terminal, so a palette
+// left on the default comes out colorless there while AgentSpec.Paint keeps emitting raw ANSI regardless
+// — a half painted frame. Passing the surface in is what prevents that.
 func TestStyles_profiledAgainstTheGivenSurface(t *testing.T) {
-	// lipgloss decides whether to emit color by profiling a writer, and its default renderer profiles
-	// os.Stdout. Under `revmux > file` stdout is a pipe while the reader watches a terminal, so
-	// a palette left on the default comes out colorless there while AgentSpec.Paint keeps emitting raw
-	// ANSI regardless — a half painted frame. Passing the surface in is what prevents that.
 	t.Run("a nil surface still builds a usable palette", func(t *testing.T) {
 		m := New(ModelConfig{Roster: roster()})
 		assert.NotEmpty(t, m.rule(), "the frame renders with no output configured, as a test wants")
@@ -68,7 +68,6 @@ func TestModel_stateStyle_coversEveryState(t *testing.T) {
 	states := []string{stateWaiting, stateRunning, stateRetrying, stateLimited, stateDone, stateDegraded}
 	for _, state := range states {
 		t.Run(state, func(t *testing.T) {
-			// rendering through the style must not drop the text, whatever the state is called
 			assert.Contains(t, m.stateStyle(state).Render(state), state)
 		})
 	}

--- a/app/ui/wrap_test.go
+++ b/app/ui/wrap_test.go
@@ -36,10 +36,10 @@ func TestWrap(t *testing.T) {
 	})
 }
 
+// markdown() runs before Wrap, so the text carries escape sequences; and prose is arbitrary, so it
+// carries multi-byte and double-width runes. Trimming a byte at a time while measuring display cells
+// exits inside a rune or inside an escape.
 func TestWrap_ansiAndRunes(t *testing.T) {
-	// **the paths that were broken.** markdown() runs before Wrap now, so the text carries escape
-	// sequences; and prose is arbitrary, so it carries multi-byte and double-width runes. Trimming a
-	// byte at a time while measuring display cells exits inside a rune or inside an escape.
 	t.Run("a cut never lands mid-rune", func(t *testing.T) {
 		for _, text := range []string{
 			strings.Repeat("ä", 200),
@@ -125,7 +125,6 @@ func TestWrap_alwaysFitsTheWidth(t *testing.T) {
 	}
 
 	t.Run("below the wrap floor it clips rather than passing the row through", func(t *testing.T) {
-		// this is the branch the plain renderer used to clip itself, before that clip was deleted
 		out := Wrap(strings.Repeat("x", 70), long, 80)
 		require.Len(t, out, 1, "too narrow to wrap into")
 		assert.LessOrEqual(t, lipgloss.Width(out[0]), 80, "but still bounded")


### PR DESCRIPTION
**comment sweep** - lowercased the non-godoc comments that opened capitalized, dropped the ones restating the line below them, and rewrote three written as history into what the code does now. Around 20 per-subtest comments moved up to their test function. Where a function carried several of them they stay above their own subtest, since merging them loses which reason explains which case.

exported struct field docs and the existing comment width are unchanged. No code changed there, and that is checked rather than asserted: every added and removed line across the 27 files starts with `//`, and each file's AST parsed with comments discarded is identical before and after.

**treewriter fix** - `TestTreeWriter_write/a_symlinked_subdirectory_leaving_the_destination_is_refused` fails on master under go 1.26.6, unrelated to the sweep. `os.Root.MkdirAll` refuses an escaping symlink now instead of reporting `ErrExist`, so `write` returned early naming only the directory it could not create. It names the entry again.
