### PR TITLE
resolve a project-level profile.md under the round's own

### DIFF
--- a/.claude-plugin/skills/revmux/SKILL.md
+++ b/.claude-plugin/skills/revmux/SKILL.md
@@ -16,7 +16,7 @@ It does no scope detection, no git, no PR fetching, no source modification. This
 |---|---|
 | resolve what is under review | supervise, stagger, retry, degrade |
 | run git, gather context | compose and archive prompts |
-| write `scope.md`, `goal.md`, `profile.md`, `context/` | merge, dedupe, verify |
+| write `scope.md`, `goal.md`, `context/` | merge, dedupe, verify |
 | choose profile, lenses, flags | return findings on stdout |
 | read the JSON, present, fix, re-run | inject prior rounds |
 
@@ -111,6 +111,25 @@ brew install umputun/apps/revmux                   # macOS
 go install github.com/umputun/revmux/app@latest    # installs as 'app'; rename to 'revmux'
 git clone https://github.com/umputun/revmux.git && cd revmux && make install
 ```
+
+### Step 0.5: Offer the project profile, once per repository
+
+`revmux config`'s `paths.profile_fallback` is `./.revmux/profile.md` when the repo has one. Every round
+without its own `input/profile.md` inherits it, and nothing creates it — not `revmux init`, not this
+skill on its own. An empty field means every review here runs on generic calibration.
+
+When it is empty, say so in one line and offer to write it. **Only ever with the user's yes**, and never
+from the diff: read the project's own rules — `CLAUDE.md`, `AGENTS.md`, `CONTRIBUTING.md`, `docs/`, the
+linter config — and write what the software is, what a real failure looks like there, the blast radius,
+the reporting bar, and which conventions are deliberate. A profile guessed from one change is the thing
+this file exists to replace.
+
+Offer it once. If he declines, do not ask again in the session, and do not write a round-local
+`input/profile.md` instead — that wins over the project file and is exactly the substitution the round
+brief forbids.
+
+**Never on a fetched pull request or any tree that is not his**: `.revmux/` is checked-in configuration,
+so authoring one there commits a review standard to somebody else's repository.
 
 ### Step 1: Resolve what is being reviewed
 

--- a/.claude-plugin/skills/revmux/SKILL.md
+++ b/.claude-plugin/skills/revmux/SKILL.md
@@ -225,13 +225,11 @@ Spawn **one** `general-purpose` agent. Hand it the resolved scope from Step 1 an
 >      that would make a later run wrong, or a contradiction that would mislead an agent executing the
 >      document. Say that finding nothing is a valid answer, or the round reads as owing findings and
 >      manufactures them.
->    - `profile` — optional, reusable across the repo. What the software is, what a real failure looks
->      like, where the project's rules live, which conventions are deliberate. **On any round after the
->      first, `cp` the previous round's file to this round's path** rather than writing one: it is about
->      the project rather than the round, so a fresh one is the same document generated again.
->      Copy from the most recent round `task-state.sh` reported `profile=present` for — the file is
->      optional, so an earlier round may not have one, and `cp` from a round that lacks it just fails.
->      Write one when no round has it.
+>    - `profile` — **do not write it.** What it holds is about the repository rather than this round, so
+>      it lives in `./.revmux/profile.md` and revmux gives every round the same one with nothing copied
+>      forward. You see the diff and the file list, which is not enough to state a repo's conventions,
+>      and a generated file here wins over the project's and silently replaces it.
+>      Write it only when the user says this subject needs a different bar than the repo's.
 >    - `context` — optional. Ticket text, design notes, commit list. Its path is reported but the
 >      directory is not created.
 >    - `task_file` — when `created` lists it, and also when it is already there but still the unfilled
@@ -243,7 +241,7 @@ Spawn **one** `general-purpose` agent. Hand it the resolved scope from Step 1 an
 >
 > **Do not read the previous round's `scope.md`, `goal.md` or `context/`.** revmux injects every prior
 > round into every composed prompt itself, so reading them buys nothing and anchors this round's scope
-> on the last one's wording. `profile.md` is the exception, and it is copied rather than read.
+> on the last one's wording. No round's `profile.md` is read either: the project file revmux resolves is not one of these.
 >
 > Return JSON only: `{"task": "", "run": "", "round_dir": "", "scope_path": "", "wrote": [],
 > "files_changed": 0, "insertions": 0, "deletions": 0, "areas": [], "notes": ""}`. `areas` names the

--- a/.claude-plugin/skills/revmux/SKILL.md
+++ b/.claude-plugin/skills/revmux/SKILL.md
@@ -226,8 +226,8 @@ Spawn **one** `general-purpose` agent. Hand it the resolved scope from Step 1 an
 >      document. Say that finding nothing is a valid answer, or the round reads as owing findings and
 >      manufactures them.
 >    - `profile` — **do not write it.** What it holds is about the repository rather than this round, so
->      it lives in `./.revmux/profile.md` and revmux gives every round the same one with nothing copied
->      forward. You see the diff and the file list, which is not enough to state a repo's conventions,
+>      it lives in `./.revmux/profile.md` and revmux gives every round without a non-empty override the same one
+>      with nothing copied forward. You see the diff and the file list, which is not enough to state a repo's conventions,
 >      and a generated file here wins over the project's and silently replaces it.
 >      Write it only when the user says this subject needs a different bar than the repo's.
 >    - `context` — optional. Ticket text, design notes, commit list. Its path is reported but the

--- a/.claude-plugin/skills/revmux/SKILL.md
+++ b/.claude-plugin/skills/revmux/SKILL.md
@@ -686,7 +686,7 @@ User: "revmux this branch"
 → git diff master...HEAD --shortstat → 22 files, +840/-310, handed to the brief as the scale
 → "Preparing the round for the branch against master…"
 → one subagent: reads the diff once, matches no existing task, derives `tui-rework`, opens
-  01-initial, writes task.md/scope/goal/profile → returns round_dir, wrote[4]
+  01-initial, writes task.md/scope/goal → returns round_dir, wrote[3]
 → revmux --task tui-rework --run 01-initial --no-tui > /tmp/…json  (background)
 → tell user: ~9 min, tail -f /tmp/…log for live progress
 → Monitor on <round_dir>/events.jsonl, milestone kinds only; one folded line a minute, silence between
@@ -698,8 +698,8 @@ User: "revmux this branch"
 User: "fix the major one and run it again"
 → fix applied
 → "Preparing the round for the fixes…" → same subagent, handed task `tui-rework` and the fixes'
-  shortstat so it neither matches a task nor re-measures; opens 02-after-fix, copies profile.md
-  across and writes its own scope
+  shortstat so it neither matches a task nor re-measures; opens 02-after-fix and writes its own
+  scope; the profile is the repo's and revmux resolves it
 → revmux --task tui-rework --run 02-after-fix --no-tui
 → exit 0, nothing above threshold
 ```

--- a/.claude-plugin/skills/revmux/references/invocation.md
+++ b/.claude-plugin/skills/revmux/references/invocation.md
@@ -313,13 +313,20 @@ everything that survived verification.
 
 Two distinct roots, and conflating them is a common failure:
 
-- **the process working directory** governs the project config layer (`./.revmux/`) and the
-  `./.revmux/tasks` default for `--tasks-dir`
+- **the process working directory** governs the project config layer (`./.revmux/`), the project profile
+  `./.revmux/profile.md` inside it, and the `./.revmux/tasks` default for `--tasks-dir`
 - **`--workdir`** sets where the review subprocesses run and what `{{WORKDIR}}` expands to
 
 Reviewing a repository from outside it therefore means passing `--workdir`, `--tasks-dir` **and**
 `--config-dir` — otherwise the first resolves to the repo and the other two to wherever the caller
 happens to be standing.
+
+**`./.revmux/profile.md` is a fourth cwd-relative input and no flag relocates it.** Reviewing repo B from
+a checkout of repo A, a round with no `input/profile.md` of its own inherits **A's** project profile, so B
+is reviewed against A's bar. Write the round its own `input/profile.md` when reviewing from outside a
+tree, or check `revmux config`'s `paths.profile_fallback` first — the run itself is not silent about it,
+since the inherited bytes are archived as `prompts/input-profile.md` and labelled in the TUI, but that is
+after the fact.
 
 ## `.revmux/` in a repository is executable trust
 

--- a/.claude-plugin/skills/revmux/references/invocation.md
+++ b/.claude-plugin/skills/revmux/references/invocation.md
@@ -405,10 +405,10 @@ An empty list always means empty. If the tasks root could not be read the reason
 if one task's directory could not be read it is `rounds_error` on that entry, and a `--workdir` that would
 not resolve is `.paths.workdir_error`. Treat any of them as "unknown", never as "nothing is there".
 
-`.paths.profile_fallback` is `./.revmux/profile.md` when the repo has one: every round with no
+`.paths.profile_fallback` is `./.revmux/profile.md` when the repo has one: every round with no non-empty
 `input/profile.md` of its own inherits it, so do not write one per round. `.paths.profile_fallback_error`
-means that file will not resolve — a round that inherits it would refuse to start, while one carrying its
-own `input/profile.md` is unaffected, since the round file wins before the project one is read.
+means that file will not resolve — a round that inherits it would refuse to start, while one with a
+non-empty `input/profile.md` is unaffected, since the round file wins before the project one is read.
 `preflight.sh` does not gate on it: it runs before the round exists and cannot know which will win.
 
 ## `revmux new` — the only call that creates anything

--- a/.claude-plugin/skills/revmux/references/invocation.md
+++ b/.claude-plugin/skills/revmux/references/invocation.md
@@ -407,7 +407,9 @@ not resolve is `.paths.workdir_error`. Treat any of them as "unknown", never as 
 
 `.paths.profile_fallback` is `./.revmux/profile.md` when the repo has one: every round with no
 `input/profile.md` of its own inherits it, so do not write one per round. `.paths.profile_fallback_error`
-means that file will not resolve, and a review would refuse to start — `preflight.sh` already fails on it.
+means that file will not resolve — a round that inherits it would refuse to start, while one carrying its
+own `input/profile.md` is unaffected, since the round file wins before the project one is read.
+`preflight.sh` does not gate on it: it runs before the round exists and cannot know which will win.
 
 ## `revmux new` — the only call that creates anything
 

--- a/.claude-plugin/skills/revmux/references/invocation.md
+++ b/.claude-plugin/skills/revmux/references/invocation.md
@@ -405,6 +405,10 @@ An empty list always means empty. If the tasks root could not be read the reason
 if one task's directory could not be read it is `rounds_error` on that entry, and a `--workdir` that would
 not resolve is `.paths.workdir_error`. Treat any of them as "unknown", never as "nothing is there".
 
+`.paths.profile_fallback` is `./.revmux/profile.md` when the repo has one: every round with no
+`input/profile.md` of its own inherits it, so do not write one per round. `.paths.profile_fallback_error`
+means that file will not resolve, and a review would refuse to start — `preflight.sh` already fails on it.
+
 ## `revmux new` — the only call that creates anything
 
 ```bash

--- a/.claude-plugin/skills/revmux/references/output.md
+++ b/.claude-plugin/skills/revmux/references/output.md
@@ -156,7 +156,8 @@ Every artifact lands in the round directory — the `round_dir` `revmux new` rep
 ├── manifest.json             roster, prompt provenance + hashes, requested vs actual model, timings
 ├── prompts/
 │   ├── agents/               composed prompt per agent, post-substitution
-│   └── stages/               synthesis.md, verify-<group>.md
+│   ├── stages/               synthesis.md, verify-<group>.md
+│   └── input-profile.md      the project profile's bytes, when the round inherited one
 ├── stages/
 │   ├── 1-found.json
 │   ├── 2-synthesized.json
@@ -183,6 +184,7 @@ the recovery path when a run's stdout was lost.
 | did verify reject wrongly? | `stages/2-synthesized.json` vs `3-verified.json` |
 | what was this agent asked? | `prompts/agents/<name>.md` |
 | which lens text, from which layer? | `manifest.json` |
+| what calibrated this round? | `input/profile.md`, or `prompts/input-profile.md` when it inherited the project's |
 
 A failed archive write fails the run. The exception is a per-agent tee, which degrades that source.
 

--- a/.claude-plugin/skills/revmux/references/task-dir.md
+++ b/.claude-plugin/skills/revmux/references/task-dir.md
@@ -27,9 +27,9 @@ not name. The layout is revmux's own detail.
 `created` names what this call made, so a second round on an existing task reports `round_dir` and
 `input_dir` alone. `context` is reported but never created — create it only when filling it.
 
-**Each round carries its own scope, goal, profile and context.** Round 2 reviews the fixes for what
-round 1 found, so it gets its own `scope.md` at its own `input/` path; round 1's is left as the record
-of what round 1 reviewed.
+**Each round carries its own scope, goal and context.** A non-empty round profile is an optional override
+of the project profile. Round 2 reviews the fixes for what round 1 found, so it gets its own `scope.md`
+at its own `input/` path; round 1's is left as the record of what round 1 reviewed.
 
 ## Variables expand to paths, never contents
 
@@ -167,12 +167,13 @@ What kind of software this is and what counts as a real failure. Without it the 
 
 Do not write this file as a matter of course. What it describes — what the software is, what a real
 failure looks like, where the rules live — belongs to the repository rather than to one round, so it
-lives in `./.revmux/profile.md` and every round of every task inherits it with nothing copied forward.
+lives in `./.revmux/profile.md` and every round without a non-empty override inherits it with nothing
+copied forward.
 `revmux config` reports the resolved path as `paths.profile_fallback`.
 
 Write a round's own `input/profile.md` only when this subject genuinely needs a different bar than the
 repo's — a vendored or generated tree, a prototype, a subsystem the project profile does not describe.
-It wins outright when present, and the project file is then not read at all.
+A non-empty round file wins outright, and the project file is then not read at all.
 
 A round that inherits gets a copy of the bytes at `prompts/input-profile.md` inside the round, and
 `{{PROFILE}}` names that copy. The archive therefore records what actually calibrated the round even

--- a/.claude-plugin/skills/revmux/references/task-dir.md
+++ b/.claude-plugin/skills/revmux/references/task-dir.md
@@ -148,7 +148,7 @@ into defects.
 With no real goal — a mechanical cleanup, a dependency bump — omit the file rather than writing a
 placeholder.
 
-## profile.md — optional, reusable across the repo
+## profile.md — optional, a per-round override of the project's own
 
 What kind of software this is and what counts as a real failure. Without it the implicit bar is
 "production service with real traffic", wrong for a personal tool or a UI surface in both directions.
@@ -165,7 +165,18 @@ What kind of software this is and what counts as a real failure. Without it the 
 - **Which languages the change actually touches** — a Go repo's conventions are not the bar for a
   commit of shell and markdown
 
-Copy it forward into each round of a task; it is the one input that rarely changes between rounds.
+Do not write this file as a matter of course. What it describes — what the software is, what a real
+failure looks like, where the rules live — belongs to the repository rather than to one round, so it
+lives in `./.revmux/profile.md` and every round of every task inherits it with nothing copied forward.
+`revmux config` reports the resolved path as `paths.profile_fallback`.
+
+Write a round's own `input/profile.md` only when this subject genuinely needs a different bar than the
+repo's — a vendored or generated tree, a prototype, a subsystem the project profile does not describe.
+It wins outright when present, and the project file is then not read at all.
+
+A round that inherits gets a copy of the bytes at `prompts/input-profile.md` inside the round, and
+`{{PROFILE}}` names that copy. The archive therefore records what actually calibrated the round even
+after the project file changes.
 
 ## context/ — optional directory
 

--- a/.claude-plugin/skills/revmux/references/triage.md
+++ b/.claude-plugin/skills/revmux/references/triage.md
@@ -76,8 +76,9 @@ it this brief with every path already expanded:
 > 4. `goal` — the maintainer's framing when he gave one, **under 1000 characters**: what he wants out of
 >    the triage, and anything he has already settled. Omit the file when he said nothing rather than
 >    inventing a frame.
-> 5. `profile` — the project's own conventions, as in Step 2. Copy the previous round's when a round has
->    one.
+> 5. `profile` — **do not write it.** It holds the project's own conventions, which revmux resolves from
+>    `./.revmux/profile.md` for every round. Write one only when the user says this item needs a
+>    different bar than the repo's.
 > 6. `context/` — one file each: the item's body in full, its whole thread in order with each comment's
 >    author, the author's own history from the command above, and any item the thread links. Curate:
 >    every file is a tool call an agent may spend.

--- a/.claude-plugin/skills/revmux/scripts/preflight.sh
+++ b/.claude-plugin/skills/revmux/scripts/preflight.sh
@@ -98,14 +98,6 @@ cfg=$(revmux config 2>/dev/null) || {
 }
 
 if command -v jq >/dev/null 2>&1; then
-    # a project profile that will not resolve fails the review at load, so reporting ok here would
-    # send the caller into a run that cannot start
-    profile_err=$(printf '%s' "$cfg" | jq -r '.paths.profile_fallback_error // empty')
-    if [ -n "$profile_err" ]; then
-        fail "project profile: UNREADABLE - $profile_err"
-        echo "hint: fix or remove ./.revmux/profile.md"
-    fi
-
     if [ -n "$profile" ]; then
         known=$(printf '%s' "$cfg" | jq -r --arg p "$profile" '[.profiles[].name] | index($p) // "null"')
         if [ "$known" = "null" ]; then

--- a/.claude-plugin/skills/revmux/scripts/preflight.sh
+++ b/.claude-plugin/skills/revmux/scripts/preflight.sh
@@ -98,6 +98,14 @@ cfg=$(revmux config 2>/dev/null) || {
 }
 
 if command -v jq >/dev/null 2>&1; then
+    # a project profile that will not resolve fails the review at load, so reporting ok here would
+    # send the caller into a run that cannot start
+    profile_err=$(printf '%s' "$cfg" | jq -r '.paths.profile_fallback_error // empty')
+    if [ -n "$profile_err" ]; then
+        fail "project profile: UNREADABLE - $profile_err"
+        echo "hint: fix or remove ./.revmux/profile.md"
+    fi
+
     if [ -n "$profile" ]; then
         known=$(printf '%s' "$cfg" | jq -r --arg p "$profile" '[.profiles[].name] | index($p) // "null"')
         if [ "$known" = "null" ]; then

--- a/.claude/rules/config.md
+++ b/.claude/rules/config.md
@@ -95,6 +95,21 @@ archived prompt carries the path and not the text.
 2. `goal.md`, `profile.md` — optional, absent resolves to the "none provided" placeholder
 3. `context/` — optional directory the caller fills with as many files as it likes
 
+**`profile.md` is the one context file with a layer under it.**
+When the round carries none, `options.projectProfile` looks for `./.revmux/profile.md` and, finding one,
+sets `reviewContext.ProfileSource` to it and `Profile` to `<round>/prompts/input-profile.md` — the path the
+snapshot will occupy. `runOpts.materializeProfile` writes those bytes through the held archive at the top of
+`review`, before the renderer is built, since the TUI's input snapshot is taken there and the agents read
+the path later still.
+It resolves through `projectDir`, **never** `o.layers.project`: `resolveLayers` empties that field when
+`--config-dir ./.revmux` collapses the two layers, and keying on it would make the fallback silently vanish
+under that one invocation while the file sat untouched on disk. `revmux config` reports the same resolution
+as `paths.profile_fallback` and must use the same method, or the catalog and the run disagree.
+The user layer is deliberately not searched: calibration that spans repositories describes none of them.
+Nothing is ever written into `input/` — a snapshot placed there would be read as an explicit round-local
+override by the next attempt on that round, and the authored project file would stop applying with nothing
+saying so.
+
 Absent `goal.md` or `profile.md` is **not an error**.
 The run proceeds, and the variable resolves to a "none provided" placeholder the shipped profile bodies
 instruct the agent to read as generic severity calibration.

--- a/.claude/rules/config.md
+++ b/.claude/rules/config.md
@@ -78,7 +78,8 @@ In documentation use the `--flag=value` form for long flags that take a value, n
 
 revmux never derives context — the caller writes it to disk and names it.
 `--task <id>` selects a directory under `--tasks-dir` (default `./.revmux/tasks`), `--run <name>` selects one
-round inside it, and `<task>/<run>/input/` is the only channel review context travels through.
+round inside it, and `<task>/<run>/input/` is the only channel a round's own context travels through —
+`./.revmux/profile.md` is the one repo-level default underneath it, resolved per the section below.
 There are no `--goal`, `--goal-file`, `--profile-file` or `--context-file` flags:
 variables resolve to **paths**, so a flag carrying inline text could not be substituted without revmux
 first writing it to a file, which would make revmux an author of context rather than a consumer of it.
@@ -536,7 +537,10 @@ denominator of every rate the analysis reports.
 **The same rule applies to every other failure this command can hit: an empty list must mean empty.**
 An unreadable tasks root reported as `"tasks": []` is the identical wrong advice one level up — it reads as
 "nothing is there" and mints a duplicate id — so it is `paths.tasks_error`, an unreadable task directory is
-`rounds_error` on that entry, and a `--workdir` that will not resolve is `paths.workdir_error` beside the
+`rounds_error` on that entry, a `./.revmux/profile.md` that will not resolve is `paths.profile_fallback_error`
+rather than a missing `profile_fallback` — the review refuses that invocation, so reporting it as no
+fallback describes a run that cannot start, and `preflight.sh` gates on the field for the same reason —
+and a `--workdir` that will not resolve is `paths.workdir_error` beside the
 raw value. An absent tasks root is the one clean case: it is a fresh install, not a failure to read one.
 
 **`configCmd.Execute` does not print.** go-flags calls it from inside `parseArgs`, before the injected

--- a/.claude/rules/config.md
+++ b/.claude/rules/config.md
@@ -32,6 +32,8 @@ revmux looks without tracking which flag a given path hangs off. `--workdir` set
 run and what `{{WORKDIR}}` expands to; reviewing a repo from outside it means passing `--config-dir` and
 `--tasks-dir` as well, since by the same rule both would otherwise resolve against the caller's cwd rather
 than the repo under review.
+`./.revmux/profile.md` is the fourth of these and the one no flag relocates, so an out-of-tree round with
+no `input/profile.md` inherits the *caller's* project profile and reviews one repo against another's bar.
 
 **`--config-dir ./.revmux` collapses the two layers into one, and that must be detected.**
 Otherwise the same directory loads twice as both the user and project layer — harmless for a scalar, but

--- a/.claude/rules/config.md
+++ b/.claude/rules/config.md
@@ -538,9 +538,13 @@ denominator of every rate the analysis reports.
 An unreadable tasks root reported as `"tasks": []` is the identical wrong advice one level up — it reads as
 "nothing is there" and mints a duplicate id — so it is `paths.tasks_error`, an unreadable task directory is
 `rounds_error` on that entry, a `./.revmux/profile.md` that will not resolve is `paths.profile_fallback_error`
-rather than a missing `profile_fallback` — the review refuses that invocation, so reporting it as no
-fallback describes a run that cannot start, and `preflight.sh` gates on the field for the same reason —
-and a `--workdir` that will not resolve is `paths.workdir_error` beside the
+rather than a missing `profile_fallback`, since reporting it as no fallback describes a round that would
+refuse to start as one that is merely uncalibrated — **it is observability and not a gate**, because
+whether it matters depends on the round: one carrying its own `input/profile.md` wins before the project
+file is read, and nothing repo-global can know that before the round exists. It also answers `os.Stat`
+rather than a read, so an unreadable regular file resolves clean here and fails later at
+`materializeProfile`; do not label the field as readability.
+And a `--workdir` that will not resolve is `paths.workdir_error` beside the
 raw value. An absent tasks root is the one clean case: it is a fresh install, not a failure to read one.
 
 **`configCmd.Execute` does not print.** go-flags calls it from inside `parseArgs`, before the injected

--- a/.claude/rules/config.md
+++ b/.claude/rules/config.md
@@ -93,11 +93,12 @@ archived prompt carries the path and not the text.
 `options.resolveContext` stats `<task>/<run>/input/` and returns the resolved absolute paths:
 
 1. `scope.md` — required, and a missing or empty one is a load-time error, since a review with no scope is a caller bug
-2. `goal.md`, `profile.md` — optional, absent resolves to the "none provided" placeholder
-3. `context/` — optional directory the caller fills with as many files as it likes
+2. `goal.md` — optional, absent resolves to the "none provided" placeholder
+3. `profile.md` — optional, absent or empty falls through to the project profile and then to the placeholder
+4. `context/` — optional directory the caller fills with as many files as it likes
 
 **`profile.md` is the one context file with a layer under it.**
-When the round carries none, `options.projectProfile` looks for `./.revmux/profile.md` and, finding one,
+When the round has no non-empty profile, `options.projectProfile` looks for `./.revmux/profile.md` and, finding one,
 sets `reviewContext.ProfileSource` to it and `Profile` to `<round>/prompts/input-profile.md` — the path the
 snapshot will occupy. `runOpts.materializeProfile` writes those bytes through the held archive at the top of
 `review`, before the renderer is built, since the TUI's input snapshot is taken there and the agents read
@@ -111,9 +112,9 @@ Nothing is ever written into `input/` — a snapshot placed there would be read 
 override by the next attempt on that round, and the authored project file would stop applying with nothing
 saying so.
 
-Absent `goal.md` or `profile.md` is **not an error**.
-The run proceeds, and the variable resolves to a "none provided" placeholder the shipped profile bodies
-instruct the agent to read as generic severity calibration.
+An absent `goal.md` is **not an error**. An absent or empty round profile falls through to the project
+profile; when that is also absent or empty, `{{PROFILE}}` resolves to the "none provided" placeholder the
+shipped profile bodies instruct the agent to read as generic severity calibration.
 That guarantee lives in the prompt text, not in Go — the report header carries the title, the scope path
 and the degraded banner, and says nothing about calibration.
 
@@ -540,7 +541,7 @@ An unreadable tasks root reported as `"tasks": []` is the identical wrong advice
 `rounds_error` on that entry, a `./.revmux/profile.md` that will not resolve is `paths.profile_fallback_error`
 rather than a missing `profile_fallback`, since reporting it as no fallback describes a round that would
 refuse to start as one that is merely uncalibrated — **it is observability and not a gate**, because
-whether it matters depends on the round: one carrying its own `input/profile.md` wins before the project
+whether it matters depends on the round: one with a non-empty `input/profile.md` wins before the project
 file is read, and nothing repo-global can know that before the round exists. It also answers `os.Stat`
 rather than a read, so an unreadable regular file resolves clean here and fails later at
 `materializeProfile`; do not label the field as readability.

--- a/.claude/rules/prompts.md
+++ b/.claude/rules/prompts.md
@@ -234,7 +234,10 @@ Variables: `{{SCOPE}}`, `{{GOAL}}`, `{{PROFILE}}`, `{{CONTEXT}}`, `{{WORKDIR}}`,
 plus `{{FINDINGS}}` and `{{SOURCES}}` for the synthesis and verify stages.
 
 **Context variables expand to absolute paths, never to file contents.**
-`{{SCOPE}}`, `{{GOAL}}` and `{{PROFILE}}` become paths to files in the round's `input/`,
+`{{SCOPE}}` and `{{GOAL}}` become paths to files in the round's `input/`, and so does `{{PROFILE}}` when
+the round carries one — otherwise it names the round's own copy of `./.revmux/profile.md`, written to
+`prompts/input-profile.md`, which is the one context variable with a layer under it.
+`.claude/rules/config.md` owns that resolution.
 `{{CONTEXT}}` becomes the path to its `context/` directory, and the profile body instructs agents to read them.
 Prompt composition therefore only stats those files and never opens one, so there is no way for a large
 scope to bloat a prompt. The TUI separately opens a bounded startup snapshot with size and encoding

--- a/.claude/rules/prompts.md
+++ b/.claude/rules/prompts.md
@@ -235,7 +235,7 @@ plus `{{FINDINGS}}` and `{{SOURCES}}` for the synthesis and verify stages.
 
 **Context variables expand to absolute paths, never to file contents.**
 `{{SCOPE}}` and `{{GOAL}}` become paths to files in the round's `input/`, and so does `{{PROFILE}}` when
-the round carries one — otherwise it names the round's own copy of `./.revmux/profile.md`, written to
+the round carries a non-empty one — otherwise it names the round's own copy of `./.revmux/profile.md`, written to
 `prompts/input-profile.md`, which is the one context variable with a layer under it.
 `.claude/rules/config.md` owns that resolution.
 `{{CONTEXT}}` becomes the path to its `context/` directory, and the profile body instructs agents to read them.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,8 @@ It does NOT do scope detection, git operations, PR fetching, issue handling, or 
 It has **zero VCS dependency** — no git library, no `git` subprocess, no repo walking.
 All context (scope description, goal, project profile, prior rounds) is written to disk by the caller and passed in.
 Agents run diff commands themselves; revmux only substitutes a path.
+The one file it opens is `./.revmux/profile.md`, and only to copy its bytes into the round so the archive
+holds them — it parses nothing and reads nothing out of them, exactly as it does not read a `scope.md`.
 If a change would make revmux read a repo, the change belongs in the caller.
 See `.claude/rules/pipeline.md`.
 
@@ -154,7 +156,8 @@ A round that has already run is a load-time error rather than an overwrite, beca
 is exactly what a reflection agent needs to read.
 A loop re-runs one task under successive run names and accumulates rounds.
 There are no `--goal`, `--goal-file`, `--profile-file` or `--context-file` flags —
-one mechanism, no precedence rules, nothing for revmux to author.
+one mechanism, nothing for revmux to author, and the only precedence anywhere in it is the round's
+`profile.md` over the project's.
 
 **revmux writes only inside a round, and nothing it does in the course of a review deletes anything.**
 `revmux new --task <id> --run <name>` is the one thing that creates any of this, and it prints the absolute

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,8 +139,8 @@ explicit round override on the next attempt, which is the silent replacement thi
 to prevent.
 
 **Review context belongs to the round, not to the task.**
-Round 2 reviews the fixes for what round 1 found, so its scope, goal, profile and context are all different
-from round 1's.
+Round 2 reviews the fixes for what round 1 found, so its scope, goal and context are all different from
+round 1's — and its profile may be, though that one usually resolves to the project file both rounds share.
 There is deliberately no task-level layer between the project file and the round: a task-level `profile.md`
 would be caller-written context that the next round's composition overwrites, which is exactly what this
 rule forbids, while the project file is settings a repository checks in once.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,8 +101,10 @@ It does NOT do scope detection, git operations, PR fetching, issue handling, or 
 It has **zero VCS dependency** — no git library, no `git` subprocess, no repo walking.
 All context (scope description, goal, project profile, prior rounds) is written to disk by the caller and passed in.
 Agents run diff commands themselves; revmux only substitutes a path.
-The one file it opens is `./.revmux/profile.md`, and only to copy its bytes into the round so the archive
-holds them — it parses nothing and reads nothing out of them, exactly as it does not read a `scope.md`.
+`./.revmux/profile.md` is the one piece of **caller review context** it opens, and only to copy its bytes
+into the round so the archive holds them; it parses nothing and reads nothing out of them.
+That is a rule about review context, not about file access — revmux also reads its config files, its whole
+prompt tree, its own prior `findings.json`, and, under the TUI, the bounded input snapshot below.
 If a change would make revmux read a repo, the change belongs in the caller.
 See `.claude/rules/pipeline.md`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ Agents run diff commands themselves; revmux only substitutes a path.
 If a change would make revmux read a repo, the change belongs in the caller.
 See `.claude/rules/pipeline.md`.
 
-**Review context arrives as a task round, and only as a task round.**
+**Review context arrives as a task round, with one repo-level default underneath it.**
 `--task <id>` names a directory under `--tasks-dir` (default `./.revmux/tasks`) and `--run <name>` names one
 round inside it. The caller fills that round's `input/` before revmux is invoked:
 
@@ -112,18 +112,38 @@ round inside it. The caller fills that round's `input/` before revmux is invoked
 <tasks-root>/<id>/
 ├── task.md                      optional, front matter describing the task itself
 ├── 01-initial/                  one round; a round is a direct child of the task
-│   ├── input/                   CALLER-written, and the only channel review context travels through
+│   ├── input/                   CALLER-written; revmux writes nothing into it, ever
 │   │   ├── scope.md    → {{SCOPE}}    required
 │   │   ├── goal.md     → {{GOAL}}     optional
-│   │   ├── profile.md  → {{PROFILE}}  optional
+│   │   ├── profile.md  → {{PROFILE}}  optional, and overrides ./.revmux/profile.md
 │   │   └── context/    → {{CONTEXT}}  optional, any number of files
 │   └── …                        revmux-owned artifacts, see the archive rule below
 └── 02-after-fix/
 ```
 
+**`./.revmux/profile.md` is the one input resolved outside the round, because it is the one input that is
+not about the round.**
+What a project is and what counts as a real failure there is the same for every task in it, so making each
+round carry a copy meant round 01 of every task — usually the broad sweep — ran on whatever the caller
+generated that time. Every other variable stays round-only: a repo-level scope or goal would describe a
+change rather than a project.
+It is the **project** layer alone — `~/.config/revmux/profile.md` is not read, since calibration that spans
+repositories describes none of them — and it resolves through `projectDir`, never through `layers.project`,
+which the `--config-dir ./.revmux` collapse empties for provenance reasons while the file stays where it is.
+A round's own `input/profile.md` wins outright, and absent-or-empty means absent in both places.
+The bytes are copied into the round as `prompts/input-profile.md` and `{{PROFILE}}` names that copy:
+the variable expands to a path, so a round pointed at the project file would carry no record of what
+calibrated it once that file changed. That copy is revmux's own artifact and goes beside the composed
+prompts — **not** into `input/`, which is the caller's. A generated file landing there would win as an
+explicit round override on the next attempt, which is the silent replacement this whole mechanism exists
+to prevent.
+
 **Review context belongs to the round, not to the task.**
 Round 2 reviews the fixes for what round 1 found, so its scope, goal, profile and context are all different
 from round 1's.
+There is deliberately no task-level layer between the project file and the round: a task-level `profile.md`
+would be caller-written context that the next round's composition overwrites, which is exactly what this
+rule forbids, while the project file is settings a repository checks in once.
 Holding them at task level makes composing round 2 overwrite the record of what round 1 actually reviewed,
 and no archive can reconstruct that afterwards — an archived prompt carries the path, not the text.
 
@@ -185,9 +205,10 @@ the final report, so a round directory holds:
 ├── input/            the caller's own scope, goal, profile and context for this round
 ├── manifest.json     resolved roster, per-lens prompt provenance + content hash,
 │                     requested vs. actual model per agent, timings
-├── prompts/          the composed prompt each agent and stage actually received,
+├── prompts/          the prompt material this run used, composed and referenced alike,
 │   ├── agents/       post-substitution — exactly the bytes the model saw
-│   └── stages/       split so a roster agent named `verify` cannot overwrite a stage prompt
+│   ├── stages/       split so a roster agent named `verify` cannot overwrite a stage prompt
+│   └── input-profile.md  the project profile's bytes, when the round inherited one
 ├── stages/           findings after find, after synthesis, after verify
 ├── events.jsonl      revmux's own decisions: stalls, retries, degrades, stage changes
 ├── agents/           verbatim tees, own subdir for the same reason
@@ -532,6 +553,11 @@ Stamping happens in `find`, not synthesis, or `--no-synthesis` runs carry invent
   No layout name is spelled anywhere else. What does not follow them
   is everything that *describes* the shape: `task.Paths` and its JSON field names, the round tree in README,
   the two in this file, the round and archive trees on all three site pages, and both skill trees.
+  **Seven files draw an actual tree diagram**, and that is the set a new artifact has to appear in:
+  this file, `README.md`, `site/index.html`, `site/docs.html`, `site/reference.html`, and
+  `references/output.md` in **each** skill tree. That last pair is the one this bullet used to miss — it
+  points at `task-dir.md`, which describes `input/` and draws no archive tree at all, so an artifact added
+  to the round is invisible to the two files a caller actually reads it out of.
 - A new `task.md` front-matter key needs: the `Meta` field with both a `yaml` and a `json` tag, and the
   commented-out line in `app/task`'s scaffolded template.
   `revmux config` reports it for free, since `taskInfo` embeds `Meta` rather than copying its fields.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ round inside it. The caller fills that round's `input/` before revmux is invoked
 │   ├── input/                   CALLER-written; revmux writes nothing into it, ever
 │   │   ├── scope.md    → {{SCOPE}}    required
 │   │   ├── goal.md     → {{GOAL}}     optional
-│   │   ├── profile.md  → {{PROFILE}}  optional, and overrides ./.revmux/profile.md
+│   │   ├── profile.md  → {{PROFILE}}  optional; non-empty overrides ./.revmux/profile.md
 │   │   └── context/    → {{CONTEXT}}  optional, any number of files
 │   └── …                        revmux-owned artifacts, see the archive rule below
 └── 02-after-fix/
@@ -132,7 +132,7 @@ change rather than a project.
 It is the **project** layer alone — `~/.config/revmux/profile.md` is not read, since calibration that spans
 repositories describes none of them — and it resolves through `projectDir`, never through `layers.project`,
 which the `--config-dir ./.revmux` collapse empties for provenance reasons while the file stays where it is.
-A round's own `input/profile.md` wins outright, and absent-or-empty means absent in both places.
+A non-empty round `input/profile.md` wins outright, and absent-or-empty means absent in both places.
 The bytes are copied into the round as `prompts/input-profile.md` and `{{PROFILE}}` names that copy:
 the variable expands to a path, so a round pointed at the project file would carry no record of what
 calibrated it once that file changed. That copy is revmux's own artifact and goes beside the composed
@@ -156,8 +156,8 @@ A round that has already run is a load-time error rather than an overwrite, beca
 is exactly what a reflection agent needs to read.
 A loop re-runs one task under successive run names and accumulates rounds.
 There are no `--goal`, `--goal-file`, `--profile-file` or `--context-file` flags —
-one mechanism, nothing for revmux to author, and the only precedence anywhere in it is the round's
-`profile.md` over the project's.
+one mechanism, nothing for revmux to author, and the only precedence anywhere in it is a non-empty
+round `profile.md` over the project's.
 
 **revmux writes only inside a round, and nothing it does in the course of a review deletes anything.**
 `revmux new --task <id> --run <name>` is the one thing that creates any of this, and it prints the absolute

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ caller-chosen and semantic; revmux allocates neither.
 <tasks-dir>/pr-123/               a task: one subject, reviewed over as many rounds as it takes
 ├── task.md                       optional; front matter identifying the task
 ├── 01-initial/                   a round
-│   ├── input/                    caller-written; the only channel review context travels through
+│   ├── input/                    caller-written; the only channel this round's own context travels through
 │   │   ├── scope.md              {{SCOPE}}    required
 │   │   ├── goal.md               {{GOAL}}     optional
 │   │   ├── profile.md            {{PROFILE}}  optional; overrides ./.revmux/profile.md

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ caller-chosen and semantic; revmux allocates neither.
 │   ├── input/                    caller-written; the only channel review context travels through
 │   │   ├── scope.md              {{SCOPE}}    required
 │   │   ├── goal.md               {{GOAL}}     optional
-│   │   ├── profile.md            {{PROFILE}}  optional, the project's own conventions
+│   │   ├── profile.md            {{PROFILE}}  optional; overrides ./.revmux/profile.md
 │   │   └── context/              {{CONTEXT}}  optional directory
 │   └── ...                       revmux-written artifacts: manifest, prompts, stages, events, tees
 └── 02-after-fix/                 the next round, with its own input/
@@ -194,6 +194,12 @@ caller-chosen and semantic; revmux allocates neither.
 Variables expand to the **paths** of these files, never to their contents, so no prompt can be bloated by a
 large scope. Context belongs to the round rather than to the task, because round 2 reviews the fixes for what
 round 1 found. A round that has already run is an error rather than an overwrite.
+
+`profile.md` is the exception, because what it says is true of the repository rather than of one round. Put
+it in `./.revmux/profile.md` and every round of every task inherits it — `revmux config` reports the
+resolved path as `paths.profile_fallback`, and the bytes are copied into each round as
+`prompts/input-profile.md` so the archive records what actually calibrated it. Write a round's own
+`input/profile.md` only to hold that subject to a different bar; it wins outright when present.
 
 Every run writes its own artifacts into that round beside the caller's `input/`: `manifest.json` with the
 resolved roster and prompt provenance, the composed prompt each agent received, the findings after every

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ caller-chosen and semantic; revmux allocates neither.
 │   ├── input/                    caller-written; the only channel this round's own context travels through
 │   │   ├── scope.md              {{SCOPE}}    required
 │   │   ├── goal.md               {{GOAL}}     optional
-│   │   ├── profile.md            {{PROFILE}}  optional; overrides ./.revmux/profile.md
+│   │   ├── profile.md            {{PROFILE}}  optional; non-empty overrides ./.revmux/profile.md
 │   │   └── context/              {{CONTEXT}}  optional directory
 │   └── ...                       revmux-written artifacts: manifest, prompts, stages, events, tees
 └── 02-after-fix/                 the next round, with its own input/
@@ -196,10 +196,10 @@ large scope. Context belongs to the round rather than to the task, because round
 round 1 found. A round that has already run is an error rather than an overwrite.
 
 `profile.md` is the exception, because what it says is true of the repository rather than of one round. Put
-it in `./.revmux/profile.md` and every round of every task inherits it — `revmux config` reports the
-resolved path as `paths.profile_fallback`, and the bytes are copied into each round as
+it in `./.revmux/profile.md` and every round without a non-empty override inherits it — `revmux config`
+reports the resolved path as `paths.profile_fallback`, and the bytes are copied into each round as
 `prompts/input-profile.md` so the archive records what actually calibrated it. Write a round's own
-`input/profile.md` only to hold that subject to a different bar; it wins outright when present.
+`input/profile.md` only to hold that subject to a different bar. A non-empty round file wins outright.
 
 Every run writes its own artifacts into that round beside the caller's `input/`: `manifest.json` with the
 resolved roster and prompt provenance, the composed prompt each agent received, the findings after every

--- a/app/artifacts.go
+++ b/app/artifacts.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"time"
 
 	"github.com/umputun/revmux/app/archive"
@@ -43,6 +44,27 @@ func (o runOpts) archiveRun(a *archive.Archive, cfg pipeline.Config, rep finding
 		return err
 	}
 	return o.writeArtifact(a, task.ManifestFile, o.manifest(cfg, rep).write)
+}
+
+// materializeProfile copies a project-level profile.md into the round; a round carrying its own needs
+// none of this, since that file already sits inside the archive.
+//
+// It runs early in review because two readers need the bytes: the agents through {{PROFILE}}, and the
+// TUI's input snapshot, taken when the renderer is built.
+func (o runOpts) materializeProfile(a *archive.Archive, rc reviewContext) error {
+	if rc.ProfileSource == "" {
+		return nil
+	}
+	body, err := os.ReadFile(rc.ProfileSource)
+	if err != nil {
+		return fmt.Errorf("read project profile %s: %w", rc.ProfileSource, err)
+	}
+	return o.writeArtifact(a, task.ProfileSnapshotFile, func(w io.Writer) error {
+		if _, writeErr := w.Write(body); writeErr != nil {
+			return fmt.Errorf("write profile snapshot: %w", writeErr)
+		}
+		return nil
+	})
 }
 
 func (o runOpts) writeArtifact(a *archive.Archive, name string, render func(io.Writer) error) error {

--- a/app/artifacts.go
+++ b/app/artifacts.go
@@ -46,8 +46,8 @@ func (o runOpts) archiveRun(a *archive.Archive, cfg pipeline.Config, rep finding
 	return o.writeArtifact(a, task.ManifestFile, o.manifest(cfg, rep).write)
 }
 
-// materializeProfile copies a project-level profile.md into the round; a round carrying its own needs
-// none of this, since that file already sits inside the archive.
+// materializeProfile copies a project-level profile.md into the round; a round carrying a non-empty
+// profile needs none of this, since that file already sits inside the archive.
 //
 // It runs early in review because two readers need the bytes: the agents through {{PROFILE}}, and the
 // TUI's input snapshot, taken when the renderer is built.

--- a/app/artifacts_test.go
+++ b/app/artifacts_test.go
@@ -52,7 +52,7 @@ func TestRun_projectProfileSnapshot(t *testing.T) {
 			"input/ is the caller's and revmux writes nothing into it")
 	})
 
-	t.Run("a round carrying its own profile is snapshotted from nothing", func(t *testing.T) {
+	t.Run("a round carrying a non-empty profile is snapshotted from nothing", func(t *testing.T) {
 		project(t)
 		r, root := archiveRun(t)
 		input := filepath.Join(root, "pr-1", "round-1", task.InputDir)
@@ -62,7 +62,7 @@ func TestRun_projectProfileSnapshot(t *testing.T) {
 		dir := filepath.Join(root, "pr-1", "round-1")
 		assert.NoFileExists(t, filepath.Join(dir, task.ProfileSnapshotFile))
 		assert.Contains(t, readFile(t, filepath.Join(dir, "prompts", "agents", "lenses.md")),
-			filepath.Join(input, task.ProfileFile), "the round's own profile wins over the project one")
+			filepath.Join(input, task.ProfileFile), "the round's non-empty profile wins over the project one")
 	})
 
 	// the snapshot is the first thing this run writes into the round, so it is also what makes an

--- a/app/artifacts_test.go
+++ b/app/artifacts_test.go
@@ -99,9 +99,11 @@ func TestRun_projectProfileSnapshot(t *testing.T) {
 			"the claim refuses first, so the finished round keeps the calibration it actually ran under")
 	})
 
-	t.Run("without a project profile an interrupted round is still reclaimable", func(t *testing.T) {
-		t.Chdir(t.TempDir())
+	t.Run("a round-local profile writes no snapshot and stays reclaimable", func(t *testing.T) {
+		project(t)
 		r, root := archiveRun(t)
+		input := filepath.Join(root, "pr-1", "round-1", task.InputDir)
+		require.NoError(t, os.WriteFile(filepath.Join(input, task.ProfileFile), []byte("# this round\n"), 0o600))
 		ro := r.opts()
 
 		review, err := ro.pipelineConfig()
@@ -109,8 +111,51 @@ func TestRun_projectProfileSnapshot(t *testing.T) {
 		require.NoError(t, ro.materializeProfile(review.archive, review.context))
 		require.NoError(t, review.archive.Close())
 
+		assert.NoFileExists(t, filepath.Join(root, "pr-1", "round-1", task.ProfileSnapshotFile))
 		reclaimed, err := archive.New(task.Round{TasksDir: root, Task: "pr-1", Run: "round-1"})
-		require.NoError(t, err, "nothing was written, so the round is still open")
+		require.NoError(t, err, "the round holds only input/ and the marker, so it is still open")
+		require.NoError(t, reclaimed.Close())
+	})
+
+	// the read finishes before Archive.Writer is called, so a source that vanishes costs the run and
+	// not the round. Only a partial revmux-owned artifact makes a round unreclaimable
+	t.Run("a source that cannot be read fails the run without burning the round", func(t *testing.T) {
+		project(t)
+		r, root := archiveRun(t)
+		ro := r.opts()
+
+		review, err := ro.pipelineConfig()
+		require.NoError(t, err)
+		require.NoError(t, os.Remove(review.context.ProfileSource))
+
+		require.Error(t, ro.materializeProfile(review.archive, review.context))
+		require.NoError(t, review.archive.Close())
+
+		assert.NoFileExists(t, filepath.Join(root, "pr-1", "round-1", task.ProfileSnapshotFile))
+		reclaimed, err := archive.New(task.Round{TasksDir: root, Task: "pr-1", Run: "round-1"})
+		require.NoError(t, err, "nothing was written into the round, so it is still open")
+		require.NoError(t, reclaimed.Close())
+	})
+
+	t.Run("a signal between the claim and the snapshot leaves the round reclaimable", func(t *testing.T) {
+		project(t)
+		r, root := archiveRun(t)
+		ro := r.opts()
+
+		review, err := ro.pipelineConfig()
+		require.NoError(t, err)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, err = ro.review(ctx, review)
+		require.Error(t, err)
+		require.NoError(t, review.archive.Close())
+
+		dir := filepath.Join(root, "pr-1", "round-1")
+		assert.NoFileExists(t, filepath.Join(dir, task.ProfileSnapshotFile))
+		assert.NoFileExists(t, filepath.Join(dir, task.EventsFile))
+		reclaimed, err := archive.New(task.Round{TasksDir: root, Task: "pr-1", Run: "round-1"})
+		require.NoError(t, err, "a round nothing reviewed must not be spent")
 		require.NoError(t, reclaimed.Close())
 	})
 }

--- a/app/artifacts_test.go
+++ b/app/artifacts_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/umputun/revmux/app/archive"
 	"github.com/umputun/revmux/app/executor"
 	"github.com/umputun/revmux/app/finding"
 	"github.com/umputun/revmux/app/pipeline"
@@ -22,6 +23,97 @@ import (
 	"github.com/umputun/revmux/app/prompt"
 	"github.com/umputun/revmux/app/task"
 )
+
+func TestRun_projectProfileSnapshot(t *testing.T) {
+	const body = "# how this project is calibrated\n"
+
+	project := func(t *testing.T) {
+		t.Helper()
+		t.Chdir(t.TempDir())
+		cwd, err := os.Getwd()
+		require.NoError(t, err)
+		require.NoError(t, os.MkdirAll(filepath.Join(cwd, projectDirName), 0o750))
+		require.NoError(t, os.WriteFile(filepath.Join(cwd, projectDirName, task.ProfileFile),
+			[]byte(body), 0o600))
+	}
+
+	t.Run("the round holds the bytes and the agents were pointed at them", func(t *testing.T) {
+		project(t)
+		r, root := archiveRun(t)
+		require.Equal(t, 1, run(r.opts()))
+
+		dir := filepath.Join(root, "pr-1", "round-1")
+		snapshot := filepath.Join(dir, task.ProfileSnapshotFile)
+		require.FileExists(t, snapshot)
+		assert.Equal(t, body, readFile(t, snapshot), "PROFILE expands to a path, so the archive keeps the bytes")
+		assert.Contains(t, readFile(t, filepath.Join(dir, "prompts", "agents", "lenses.md")), snapshot,
+			"the composed prompt names the round's snapshot, never the project file outside it")
+		assert.NoFileExists(t, filepath.Join(dir, task.InputDir, task.ProfileFile),
+			"input/ is the caller's and revmux writes nothing into it")
+	})
+
+	t.Run("a round carrying its own profile is snapshotted from nothing", func(t *testing.T) {
+		project(t)
+		r, root := archiveRun(t)
+		input := filepath.Join(root, "pr-1", "round-1", task.InputDir)
+		require.NoError(t, os.WriteFile(filepath.Join(input, task.ProfileFile), []byte("# this round only\n"), 0o600))
+		require.Equal(t, 1, run(r.opts()))
+
+		dir := filepath.Join(root, "pr-1", "round-1")
+		assert.NoFileExists(t, filepath.Join(dir, task.ProfileSnapshotFile))
+		assert.Contains(t, readFile(t, filepath.Join(dir, "prompts", "agents", "lenses.md")),
+			filepath.Join(input, task.ProfileFile), "the round's own profile wins over the project one")
+	})
+
+	// the snapshot is the first thing this run writes into the round, so it is also what makes an
+	// interrupted round unreclaimable. That is deliberate — two runs' artifacts under one manifest is
+	// the un-auditable archive CheckReclaim exists to refuse — but it must be the real refusal
+	t.Run("an interrupted round that got a snapshot is refused rather than re-used", func(t *testing.T) {
+		project(t)
+		r, root := archiveRun(t)
+		ro := r.opts()
+
+		review, err := ro.pipelineConfig()
+		require.NoError(t, err)
+		require.NoError(t, ro.materializeProfile(review.archive, review.context))
+		require.NoError(t, review.archive.Close())
+
+		_, err = archive.New(task.Round{TasksDir: root, Task: "pr-1", Run: "round-1"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "prompts", "the refusal names what the dead run left behind")
+	})
+
+	t.Run("a round that already ran is refused before anything is written over it", func(t *testing.T) {
+		project(t)
+		r, root := archiveRun(t)
+		require.Equal(t, 1, run(r.opts()))
+
+		cwd, err := os.Getwd()
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(cwd, projectDirName, task.ProfileFile),
+			[]byte("# rewritten after the round ran\n"), 0o600))
+
+		second := newRunOpts(t, r.o)
+		require.Equal(t, 2, run(second.opts()))
+		assert.Equal(t, body, readFile(t, filepath.Join(root, "pr-1", "round-1", task.ProfileSnapshotFile)),
+			"the claim refuses first, so the finished round keeps the calibration it actually ran under")
+	})
+
+	t.Run("without a project profile an interrupted round is still reclaimable", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+		r, root := archiveRun(t)
+		ro := r.opts()
+
+		review, err := ro.pipelineConfig()
+		require.NoError(t, err)
+		require.NoError(t, ro.materializeProfile(review.archive, review.context))
+		require.NoError(t, review.archive.Close())
+
+		reclaimed, err := archive.New(task.Round{TasksDir: root, Task: "pr-1", Run: "round-1"})
+		require.NoError(t, err, "nothing was written, so the round is still open")
+		require.NoError(t, reclaimed.Close())
+	})
+}
 
 func TestRun_archive(t *testing.T) {
 	t.Run("the run directory holds every artifact a later reader needs", func(t *testing.T) {

--- a/app/config.go
+++ b/app/config.go
@@ -104,6 +104,11 @@ type reviewContext struct {
 	Profile  string
 	Context  string
 	WorkDir  string
+
+	// set only when the round carries no profile of its own and the project layer has one. Profile
+	// then names this run's snapshot rather than a path outside the round, so the archive stays
+	// self-contained when the project file later changes.
+	ProfileSource string
 }
 
 // parseArgs parses the command line, then layers the project and user INI files underneath it, and
@@ -352,6 +357,14 @@ func (o options) resolveContext() (reviewContext, error) {
 	if rc.Profile, err = o.contextFile(filepath.Join(input, task.ProfileFile)); err != nil {
 		return reviewContext{}, err
 	}
+	if rc.Profile == "" {
+		if rc.ProfileSource, err = o.projectProfile(); err != nil {
+			return reviewContext{}, err
+		}
+		if rc.ProfileSource != "" {
+			rc.Profile = filepath.Join(dir, o.Run, task.ProfileSnapshotFile)
+		}
+	}
 	if rc.Context, err = o.contextDir(filepath.Join(input, task.ContextDir)); err != nil {
 		return reviewContext{}, err
 	}
@@ -359,6 +372,19 @@ func (o options) resolveContext() (reviewContext, error) {
 		return reviewContext{}, err
 	}
 	return rc, nil
+}
+
+// projectProfile is ./.revmux/profile.md, the repo-wide calibration a round carrying none of its own
+// inherits. It keys on projectDir rather than on layers.project, which the --config-dir ./.revmux
+// collapse empties for provenance reasons while the file itself stays exactly where it was — reading
+// the layer there would make the fallback vanish under one invocation and nothing would say so.
+// Absent and empty both mean no project profile, the same rule contextFile applies inside a round.
+func (o options) projectProfile() (string, error) {
+	dir, err := projectDir()
+	if err != nil {
+		return "", err
+	}
+	return o.contextFile(filepath.Join(dir, task.ProfileFile))
 }
 
 // taskDir joins the task name onto the tasks root and verifies the result stays inside it. Containment is

--- a/app/config.go
+++ b/app/config.go
@@ -105,9 +105,9 @@ type reviewContext struct {
 	Context  string
 	WorkDir  string
 
-	// set only when the round carries no profile of its own and the project layer has one. Profile
-	// then names this run's snapshot rather than a path outside the round, so the archive stays
-	// self-contained when the project file later changes.
+	// set only when the round carries no non-empty profile of its own and the project layer has one.
+	// Profile then names this run's snapshot rather than a path outside the round, so the archive
+	// stays self-contained when the project file later changes.
 	ProfileSource string
 }
 
@@ -374,7 +374,7 @@ func (o options) resolveContext() (reviewContext, error) {
 	return rc, nil
 }
 
-// projectProfile is ./.revmux/profile.md, the repo-wide calibration a round carrying none of its own
+// projectProfile is ./.revmux/profile.md, the repo-wide calibration a round with no non-empty profile
 // inherits. It keys on projectDir rather than on layers.project, which the --config-dir ./.revmux
 // collapse empties for provenance reasons while the file itself stays exactly where it was — reading
 // the layer there would make the fallback vanish under one invocation and nothing would say so.

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -819,19 +819,31 @@ func TestResolveContext_projectProfileFallback(t *testing.T) {
 			"PROFILE must name the round's own snapshot, never a path outside the round")
 	})
 
-	t.Run("a round with its own profile wins over the project one", func(t *testing.T) {
+	t.Run("a round with a non-empty profile wins over the project one", func(t *testing.T) {
 		root, _ := setup(t, "# project calibration\n")
 		input := roundInput(t, root, "pr-1", task.ScopeFile, task.ProfileFile)
 
 		rc, err := options{Task: "pr-1", Run: testRun, TasksDir: root}.resolveContext()
 		require.NoError(t, err)
-		assert.Empty(t, rc.ProfileSource, "nothing is snapshotted when the round carries its own")
+		assert.Empty(t, rc.ProfileSource, "nothing is snapshotted when the round carries a non-empty profile")
 		assert.Equal(t, filepath.Join(input, task.ProfileFile), rc.Profile)
 	})
 
-	// the project file is never opened when the round has its own, so a broken one must not fail an
+	t.Run("an empty round profile inherits the project one", func(t *testing.T) {
+		root, cwd := setup(t, "# project calibration\n")
+		input := roundInput(t, root, "pr-1", task.ScopeFile, task.ProfileFile)
+		require.NoError(t, os.WriteFile(filepath.Join(input, task.ProfileFile), nil, 0o600))
+
+		rc, err := options{Task: "pr-1", Run: testRun, TasksDir: root}.resolveContext()
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(cwd, projectDirName, task.ProfileFile), rc.ProfileSource)
+		assert.Equal(t, filepath.Join(root, "pr-1", testRun, task.ProfileSnapshotFile), rc.Profile,
+			"an empty round file is absent for precedence, so PROFILE must name the project snapshot")
+	})
+
+	// the project file is never opened when the round has a non-empty profile, so a broken one must not fail an
 	// invocation that would never have read it
-	t.Run("a broken project profile is irrelevant when the round carries its own", func(t *testing.T) {
+	t.Run("a broken project profile is irrelevant when the round carries a non-empty profile", func(t *testing.T) {
 		root, cwd := setup(t, "")
 		require.NoError(t, os.MkdirAll(filepath.Join(cwd, projectDirName, task.ProfileFile), 0o750))
 		input := roundInput(t, root, "pr-1", task.ScopeFile, task.ProfileFile)

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -790,3 +790,64 @@ func readFile(t *testing.T, path string) string {
 	require.NoError(t, err)
 	return string(data)
 }
+
+func TestResolveContext_projectProfileFallback(t *testing.T) {
+	// the project layer resolves against the process working directory, so each case chdirs into its own
+	// tree and reads the cwd back: a temp dir under /var is really /private/var on macOS, and a path
+	// built from t.TempDir() would not match the one filepath.Abs produces inside projectDir
+	setup := func(t *testing.T, body string) (root, cwd string) {
+		t.Helper()
+		t.Chdir(t.TempDir())
+		cwd, err := os.Getwd()
+		require.NoError(t, err)
+		if body != "" {
+			require.NoError(t, os.MkdirAll(filepath.Join(cwd, projectDirName), 0o750))
+			require.NoError(t, os.WriteFile(filepath.Join(cwd, projectDirName, task.ProfileFile),
+				[]byte(body), 0o600))
+		}
+		return t.TempDir(), cwd
+	}
+
+	t.Run("a round with no profile inherits the project one", func(t *testing.T) {
+		root, cwd := setup(t, "# project calibration\n")
+		roundInput(t, root, "pr-1", task.ScopeFile)
+
+		rc, err := options{Task: "pr-1", Run: testRun, TasksDir: root}.resolveContext()
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(cwd, projectDirName, task.ProfileFile), rc.ProfileSource)
+		assert.Equal(t, filepath.Join(root, "pr-1", testRun, task.ProfileSnapshotFile), rc.Profile,
+			"PROFILE must name the round's own snapshot, never a path outside the round")
+	})
+
+	t.Run("a round with its own profile wins over the project one", func(t *testing.T) {
+		root, _ := setup(t, "# project calibration\n")
+		input := roundInput(t, root, "pr-1", task.ScopeFile, task.ProfileFile)
+
+		rc, err := options{Task: "pr-1", Run: testRun, TasksDir: root}.resolveContext()
+		require.NoError(t, err)
+		assert.Empty(t, rc.ProfileSource, "nothing is snapshotted when the round carries its own")
+		assert.Equal(t, filepath.Join(input, task.ProfileFile), rc.Profile)
+	})
+
+	t.Run("no project profile leaves the placeholder", func(t *testing.T) {
+		root, _ := setup(t, "")
+		roundInput(t, root, "pr-1", task.ScopeFile)
+
+		rc, err := options{Task: "pr-1", Run: testRun, TasksDir: root}.resolveContext()
+		require.NoError(t, err)
+		assert.Empty(t, rc.ProfileSource)
+		assert.Empty(t, rc.Profile)
+	})
+
+	t.Run("an empty project profile is no project profile", func(t *testing.T) {
+		root, cwd := setup(t, "")
+		require.NoError(t, os.MkdirAll(filepath.Join(cwd, projectDirName), 0o750))
+		require.NoError(t, os.WriteFile(filepath.Join(cwd, projectDirName, task.ProfileFile), nil, 0o600))
+		roundInput(t, root, "pr-1", task.ScopeFile)
+
+		rc, err := options{Task: "pr-1", Run: testRun, TasksDir: root}.resolveContext()
+		require.NoError(t, err)
+		assert.Empty(t, rc.ProfileSource, "empty and absent already mean the same thing inside a round")
+		assert.Empty(t, rc.Profile)
+	})
+}

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -829,6 +829,29 @@ func TestResolveContext_projectProfileFallback(t *testing.T) {
 		assert.Equal(t, filepath.Join(input, task.ProfileFile), rc.Profile)
 	})
 
+	// the project file is never opened when the round has its own, so a broken one must not fail an
+	// invocation that would never have read it
+	t.Run("a broken project profile is irrelevant when the round carries its own", func(t *testing.T) {
+		root, cwd := setup(t, "")
+		require.NoError(t, os.MkdirAll(filepath.Join(cwd, projectDirName, task.ProfileFile), 0o750))
+		input := roundInput(t, root, "pr-1", task.ScopeFile, task.ProfileFile)
+
+		rc, err := options{Task: "pr-1", Run: testRun, TasksDir: root}.resolveContext()
+		require.NoError(t, err)
+		assert.Empty(t, rc.ProfileSource)
+		assert.Equal(t, filepath.Join(input, task.ProfileFile), rc.Profile)
+	})
+
+	t.Run("a broken project profile fails a round that would inherit it", func(t *testing.T) {
+		root, cwd := setup(t, "")
+		require.NoError(t, os.MkdirAll(filepath.Join(cwd, projectDirName, task.ProfileFile), 0o750))
+		roundInput(t, root, "pr-1", task.ScopeFile)
+
+		_, err := options{Task: "pr-1", Run: testRun, TasksDir: root}.resolveContext()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "want a file")
+	})
+
 	t.Run("no project profile leaves the placeholder", func(t *testing.T) {
 		root, _ := setup(t, "")
 		roundInput(t, root, "pr-1", task.ScopeFile)

--- a/app/inputsnapshot.go
+++ b/app/inputsnapshot.go
@@ -53,9 +53,20 @@ func (s *inputSnapshotter) load(rc reviewContext) []ui.InputDocument {
 		s.file(inputFile{label: "scope", relative: filepath.Join(task.InputDir, task.ScopeFile), path: rc.Scope}))
 	docs = append(docs, s.optional(inputFile{label: "goal", relative: filepath.Join(task.InputDir, task.GoalFile),
 		path: s.inputPath(rc, task.GoalFile, rc.Goal)})...)
-	docs = append(docs, s.optional(inputFile{label: "profile", relative: filepath.Join(task.InputDir, task.ProfileFile),
-		path: s.inputPath(rc, task.ProfileFile, rc.Profile)})...)
+	docs = append(docs, s.optional(s.profileFile(rc))...)
 	return append(docs, s.context(rc.Context)...)
+}
+
+// profileFile labels the profile tab by where the bytes actually came from. Under the project fallback
+// the round holds no input/profile.md, so reconstructing that path would report the tab absent and show
+// a calibrated run as an uncalibrated one — the snapshot is what the agents read and is what the reader
+// must see.
+func (s *inputSnapshotter) profileFile(rc reviewContext) inputFile {
+	if rc.ProfileSource != "" {
+		return inputFile{label: "profile", relative: task.ProfileSnapshotFile, path: rc.Profile}
+	}
+	return inputFile{label: "profile", relative: filepath.Join(task.InputDir, task.ProfileFile),
+		path: s.inputPath(rc, task.ProfileFile, rc.Profile)}
 }
 
 // inputPath preserves an optional file's existence for the display snapshot without changing the

--- a/app/inputsnapshot.go
+++ b/app/inputsnapshot.go
@@ -58,9 +58,9 @@ func (s *inputSnapshotter) load(rc reviewContext) []ui.InputDocument {
 }
 
 // profileFile labels the profile tab by where the bytes actually came from. Under the project fallback
-// the round holds no input/profile.md, so reconstructing that path would report the tab absent and show
-// a calibrated run as an uncalibrated one — the snapshot is what the agents read and is what the reader
-// must see.
+// the round holds no non-empty input/profile.md, so reconstructing that path would report the tab
+// absent and show a calibrated run as an uncalibrated one — the snapshot is what the agents read and
+// is what the reader must see.
 func (s *inputSnapshotter) profileFile(rc reviewContext) inputFile {
 	if rc.ProfileSource != "" {
 		return inputFile{label: "profile", relative: task.ProfileSnapshotFile, path: rc.Profile}

--- a/app/inputsnapshot_test.go
+++ b/app/inputsnapshot_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/umputun/revmux/app/task"
 )
 
 func TestInputSnapshotter_load(t *testing.T) {
@@ -47,6 +49,26 @@ func TestInputSnapshotter_load(t *testing.T) {
 		assert.Empty(t, snapshot[1].Content)
 		assert.Empty(t, snapshot[1].Notice, "the renderer identifies this as an empty file")
 	})
+}
+
+// inputPath rebuilds the round-local path and reports the tab absent when that file is missing, which
+// under the project fallback would hide a profile the agents were reading — a calibrated run shown as
+// an uncalibrated one
+func TestInputSnapshotter_projectProfileKeepsItsTab(t *testing.T) {
+	root := t.TempDir()
+	scope := filepath.Join(root, task.ScopeFile)
+	require.NoError(t, os.WriteFile(scope, []byte("scope"), 0o600))
+	snapshot := filepath.Join(root, "input-profile.md")
+	require.NoError(t, os.WriteFile(snapshot, []byte("# project calibration"), 0o600))
+
+	docs := (&inputSnapshotter{limits: inputLimits{
+		fileBytes: 1024, totalBytes: 4096, contexts: 2, entries: 10,
+	}}).load(reviewContext{InputDir: root, Scope: scope, Profile: snapshot, ProfileSource: "/elsewhere/profile.md"})
+
+	require.Len(t, docs, 2)
+	assert.Equal(t, "profile", docs[1].Label)
+	assert.Equal(t, task.ProfileSnapshotFile, docs[1].Path, "labeled by where the bytes really came from")
+	assert.Equal(t, "# project calibration", docs[1].Content)
 }
 
 func TestInputSnapshotter_limits(t *testing.T) {

--- a/app/introspect.go
+++ b/app/introspect.go
@@ -85,13 +85,14 @@ type vocabulary struct {
 // WorkDirError carry why a field is the raw flag: an unreadable tasks root reported as no tasks reads
 // as "nothing is there" and mints a duplicate id.
 type pathInfo struct {
-	TasksDir     string     `json:"tasks_dir"`
-	TasksError   string     `json:"tasks_error,omitempty"`
-	ConfigDir    string     `json:"config_dir"`
-	ProjectDir   string     `json:"project_dir,omitempty"`
-	WorkDir      string     `json:"workdir"`
-	WorkDirError string     `json:"workdir_error,omitempty"`
-	Tasks        []taskInfo `json:"tasks"`
+	TasksDir        string     `json:"tasks_dir"`
+	TasksError      string     `json:"tasks_error,omitempty"`
+	ConfigDir       string     `json:"config_dir"`
+	ProjectDir      string     `json:"project_dir,omitempty"`
+	ProfileFallback string     `json:"profile_fallback,omitempty"`
+	WorkDir         string     `json:"workdir"`
+	WorkDirError    string     `json:"workdir_error,omitempty"`
+	Tasks           []taskInfo `json:"tasks"`
 }
 
 // taskInfo is one existing task: its id, what its task.md says about it, and the rounds already recorded
@@ -191,6 +192,11 @@ func (o options) knobs() []knob {
 func (o options) paths() pathInfo {
 	p := pathInfo{TasksDir: o.TasksDir, ConfigDir: o.layers.user, ProjectDir: o.layers.project,
 		WorkDir: o.WorkDir, Tasks: []taskInfo{}}
+	// reported so a caller can tell a round it left without a profile will still be calibrated. A read
+	// failure is left silent here: the review reports it, and this command is not where it is decided
+	if fallback, err := o.projectProfile(); err == nil {
+		p.ProfileFallback = fallback
+	}
 	if dir, err := o.workDir(); err != nil {
 		p.WorkDirError = err.Error()
 	} else {

--- a/app/introspect.go
+++ b/app/introspect.go
@@ -85,15 +85,15 @@ type vocabulary struct {
 // WorkDirError carry why a field is the raw flag: an unreadable tasks root reported as no tasks reads
 // as "nothing is there" and mints a duplicate id.
 type pathInfo struct {
-	TasksDir        string     `json:"tasks_dir"`
-	TasksError      string     `json:"tasks_error,omitempty"`
-	ConfigDir       string     `json:"config_dir"`
-	ProjectDir      string     `json:"project_dir,omitempty"`
-	ProfileFallback      string `json:"profile_fallback,omitempty"`
-	ProfileFallbackError string `json:"profile_fallback_error,omitempty"`
-	WorkDir         string     `json:"workdir"`
-	WorkDirError    string     `json:"workdir_error,omitempty"`
-	Tasks           []taskInfo `json:"tasks"`
+	TasksDir             string     `json:"tasks_dir"`
+	TasksError           string     `json:"tasks_error,omitempty"`
+	ConfigDir            string     `json:"config_dir"`
+	ProjectDir           string     `json:"project_dir,omitempty"`
+	ProfileFallback      string     `json:"profile_fallback,omitempty"`
+	ProfileFallbackError string     `json:"profile_fallback_error,omitempty"`
+	WorkDir              string     `json:"workdir"`
+	WorkDirError         string     `json:"workdir_error,omitempty"`
+	Tasks                []taskInfo `json:"tasks"`
 }
 
 // taskInfo is one existing task: its id, what its task.md says about it, and the rounds already recorded
@@ -193,8 +193,8 @@ func (o options) knobs() []knob {
 func (o options) paths() pathInfo {
 	p := pathInfo{TasksDir: o.TasksDir, ConfigDir: o.layers.user, ProjectDir: o.layers.project,
 		WorkDir: o.WorkDir, Tasks: []taskInfo{}}
-	// a failure reported as no fallback describes an invocation the review would refuse to start, which
-	// is the same wrong advice tasks_error and workdir_error exist to prevent
+	// a failure reported as no fallback describes an inheriting round as uncalibrated when it would
+	// refuse to start, which is the same wrong advice tasks_error and workdir_error exist to prevent
 	if fallback, err := o.projectProfile(); err != nil {
 		p.ProfileFallbackError = err.Error()
 	} else {

--- a/app/introspect.go
+++ b/app/introspect.go
@@ -89,7 +89,8 @@ type pathInfo struct {
 	TasksError      string     `json:"tasks_error,omitempty"`
 	ConfigDir       string     `json:"config_dir"`
 	ProjectDir      string     `json:"project_dir,omitempty"`
-	ProfileFallback string     `json:"profile_fallback,omitempty"`
+	ProfileFallback      string `json:"profile_fallback,omitempty"`
+	ProfileFallbackError string `json:"profile_fallback_error,omitempty"`
 	WorkDir         string     `json:"workdir"`
 	WorkDirError    string     `json:"workdir_error,omitempty"`
 	Tasks           []taskInfo `json:"tasks"`
@@ -192,9 +193,11 @@ func (o options) knobs() []knob {
 func (o options) paths() pathInfo {
 	p := pathInfo{TasksDir: o.TasksDir, ConfigDir: o.layers.user, ProjectDir: o.layers.project,
 		WorkDir: o.WorkDir, Tasks: []taskInfo{}}
-	// reported so a caller can tell a round it left without a profile will still be calibrated. A read
-	// failure is left silent here: the review reports it, and this command is not where it is decided
-	if fallback, err := o.projectProfile(); err == nil {
+	// a failure reported as no fallback describes an invocation the review would refuse to start, which
+	// is the same wrong advice tasks_error and workdir_error exist to prevent
+	if fallback, err := o.projectProfile(); err != nil {
+		p.ProfileFallbackError = err.Error()
+	} else {
 		p.ProfileFallback = fallback
 	}
 	if dir, err := o.workDir(); err != nil {

--- a/app/introspect_test.go
+++ b/app/introspect_test.go
@@ -193,6 +193,24 @@ func TestOptions_paths(t *testing.T) {
 	assert.Equal(t, []taskInfo{{ID: "pr-1", Rounds: []string{}}, {ID: "pr-2", Rounds: []string{}}}, got.Tasks,
 		"only directories are tasks, and a --run collides with an existing round")
 
+	// the collapse empties layers.project for provenance while the file stays where it is, so reading
+	// the layer here would report no fallback on an invocation that still uses one
+	t.Run("the profile fallback is reported and survives --config-dir ./.revmux", func(t *testing.T) {
+		dir := isolate(t)
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, projectDirName), 0o750))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, projectDirName, task.ProfileFile),
+			[]byte("# calibration"), 0o600))
+
+		got := options{TasksDir: root, layers: configLayers{}}.paths()
+		assert.Equal(t, filepath.Join(dir, projectDirName, task.ProfileFile), got.ProfileFallback)
+		assert.Empty(t, got.ProjectDir, "the layer is collapsed, and the fallback is reported regardless")
+	})
+
+	t.Run("no project profile reports no fallback", func(t *testing.T) {
+		isolate(t)
+		assert.Empty(t, options{TasksDir: root}.paths().ProfileFallback)
+	})
+
 	t.Run("a relative tasks root resolves against the working directory", func(t *testing.T) {
 		dir := isolate(t)
 		got := options{TasksDir: "./.revmux/tasks"}.paths()

--- a/app/introspect_test.go
+++ b/app/introspect_test.go
@@ -208,7 +208,20 @@ func TestOptions_paths(t *testing.T) {
 
 	t.Run("no project profile reports no fallback", func(t *testing.T) {
 		isolate(t)
-		assert.Empty(t, options{TasksDir: root}.paths().ProfileFallback)
+		got := options{TasksDir: root}.paths()
+		assert.Empty(t, got.ProfileFallback)
+		assert.Empty(t, got.ProfileFallbackError)
+	})
+
+	// reported as absent, this describes an invocation the review would refuse to start — the same
+	// wrong advice tasks_error and workdir_error exist to prevent one level up
+	t.Run("a profile that will not resolve is an error rather than an absence", func(t *testing.T) {
+		dir := isolate(t)
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, projectDirName, task.ProfileFile), 0o750))
+
+		got := options{TasksDir: root}.paths()
+		assert.Empty(t, got.ProfileFallback)
+		assert.Contains(t, got.ProfileFallbackError, "want a file")
 	})
 
 	t.Run("a relative tasks root resolves against the working directory", func(t *testing.T) {

--- a/app/introspect_test.go
+++ b/app/introspect_test.go
@@ -213,8 +213,8 @@ func TestOptions_paths(t *testing.T) {
 		assert.Empty(t, got.ProfileFallbackError)
 	})
 
-	// reported as absent, this describes an invocation the review would refuse to start — the same
-	// wrong advice tasks_error and workdir_error exist to prevent one level up
+	// reported as absent, this describes an inheriting round as uncalibrated when it would refuse to
+	// start — the same wrong advice tasks_error and workdir_error exist to prevent one level up
 	t.Run("a profile that will not resolve is an error rather than an absence", func(t *testing.T) {
 		dir := isolate(t)
 		require.NoError(t, os.MkdirAll(filepath.Join(dir, projectDirName, task.ProfileFile), 0o750))

--- a/app/main.go
+++ b/app/main.go
@@ -217,6 +217,11 @@ func (o runOpts) pipelineConfig() (configuredReview, error) {
 // the browser is a rendering path like stdout is.
 func (o runOpts) review(ctx context.Context, review configuredReview) (finding.Report, error) {
 	cfg, arc := review.pipeline, review.archive
+	// the snapshot is the first artifact written into the round, so a signal that arrived between the
+	// claim and here must stop before it: writing one burns a round nothing has reviewed
+	if err := ctx.Err(); err != nil {
+		return finding.Report{}, fmt.Errorf("review canceled: %w", err)
+	}
 	if err := o.materializeProfile(arc, review.context); err != nil {
 		return finding.Report{}, err
 	}

--- a/app/main.go
+++ b/app/main.go
@@ -217,6 +217,9 @@ func (o runOpts) pipelineConfig() (configuredReview, error) {
 // the browser is a rendering path like stdout is.
 func (o runOpts) review(ctx context.Context, review configuredReview) (finding.Report, error) {
 	cfg, arc := review.pipeline, review.archive
+	if err := o.materializeProfile(arc, review.context); err != nil {
+		return finding.Report{}, err
+	}
 	p := pipeline.New(cfg)
 	r := o.render(renderConfig{
 		roster: cfg.Roster, events: p.Events(), context: review.context,

--- a/app/main.go
+++ b/app/main.go
@@ -217,8 +217,8 @@ func (o runOpts) pipelineConfig() (configuredReview, error) {
 // the browser is a rendering path like stdout is.
 func (o runOpts) review(ctx context.Context, review configuredReview) (finding.Report, error) {
 	cfg, arc := review.pipeline, review.archive
-	// the snapshot is the first artifact written into the round, so a signal that arrived between the
-	// claim and here must stop before it: writing one burns a round nothing has reviewed
+	// the snapshot is the first post-claim artifact, so a signal that arrived between the claim and here
+	// must stop before it: writing one burns a round nothing has reviewed
 	if err := ctx.Err(); err != nil {
 		return finding.Report{}, fmt.Errorf("review canceled: %w", err)
 	}

--- a/app/task/task.go
+++ b/app/task/task.go
@@ -48,6 +48,11 @@ const (
 	StagePromptDir = "prompts/stages"
 )
 
+// ProfileSnapshotFile is the round's copy of a project-level profile.md, taken when the round carries
+// none of its own. {{PROFILE}} expands to a path rather than to content, so a round pointed at the
+// project file would carry no record of what calibrated it once that file changed.
+const ProfileSnapshotFile = "prompts/input-profile.md"
+
 // FoundFile, SynthesizedFile and VerifiedFile are the per-stage findings snapshots. Each is a
 // finding.Report, so each carries the full source roster alongside that stage's findings.
 const (

--- a/app/task/task.go
+++ b/app/task/task.go
@@ -49,8 +49,8 @@ const (
 )
 
 // ProfileSnapshotFile is the round's copy of a project-level profile.md, taken when the round carries
-// none of its own. {{PROFILE}} expands to a path rather than to content, so a round pointed at the
-// project file would carry no record of what calibrated it once that file changed.
+// no non-empty profile of its own. {{PROFILE}} expands to a path rather than to content, so a round
+// pointed at the project file would carry no record of what calibrated it once that file changed.
 const ProfileSnapshotFile = "prompts/input-profile.md"
 
 // FoundFile, SynthesizedFile and VerifiedFile are the per-stage findings snapshots. Each is a

--- a/plugins/codex/skills/revmux/SKILL.md
+++ b/plugins/codex/skills/revmux/SKILL.md
@@ -231,13 +231,11 @@ Hand it the resolved scope from Step 1 and this brief:
 >      that would make a later run wrong, or a contradiction that would mislead an agent executing the
 >      document. Say that finding nothing is a valid answer, or the round reads as owing findings and
 >      manufactures them.
->    - `profile` — optional, reusable across the repo. What the software is, what a real failure looks
->      like, where the project's rules live, which conventions are deliberate. **On any round after the
->      first, `cp` the previous round's file to this round's path** rather than writing one: it is about
->      the project rather than the round, so a fresh one is the same document generated again.
->      Copy from the most recent round `task-state.sh` reported `profile=present` for — the file is
->      optional, so an earlier round may not have one, and `cp` from a round that lacks it just fails.
->      Write one when no round has it.
+>    - `profile` — **do not write it.** What it holds is about the repository rather than this round, so
+>      it lives in `./.revmux/profile.md` and revmux gives every round the same one with nothing copied
+>      forward. You see the diff and the file list, which is not enough to state a repo's conventions,
+>      and a generated file here wins over the project's and silently replaces it.
+>      Write it only when the user says this subject needs a different bar than the repo's.
 >    - `context` — optional. Ticket text, design notes, commit list. Its path is reported but the
 >      directory is not created.
 >    - `task_file` — when `created` lists it, and also when it is already there but still the unfilled
@@ -249,7 +247,7 @@ Hand it the resolved scope from Step 1 and this brief:
 >
 > **Do not read the previous round's `scope.md`, `goal.md` or `context/`.** revmux injects every prior
 > round into every composed prompt itself, so reading them buys nothing and anchors this round's scope
-> on the last one's wording. `profile.md` is the exception, and it is copied rather than read.
+> on the last one's wording. No round's `profile.md` is read either: the project file revmux resolves is not one of these.
 >
 > Return JSON only: `{"task": "", "run": "", "round_dir": "", "scope_path": "", "wrote": [],
 > "files_changed": 0, "insertions": 0, "deletions": 0, "areas": [], "notes": ""}`. `areas` names the

--- a/plugins/codex/skills/revmux/SKILL.md
+++ b/plugins/codex/skills/revmux/SKILL.md
@@ -696,7 +696,7 @@ User: "revmux this branch"
 → git diff master...HEAD --shortstat → 22 files, +840/-310, handed to the brief as the scale
 → "Preparing the round for the branch against master…"
 → one subagent: reads the diff once, matches no existing task, derives `tui-rework`, opens
-  01-initial, writes task.md/scope/goal/profile → returns round_dir, wrote[4]
+  01-initial, writes task.md/scope/goal → returns round_dir, wrote[3]
 → revmux --task tui-rework --run 01-initial --no-tui > /tmp/…json  (background)
 → tell user: ~9 min, tail -f /tmp/…log for live progress
 → yielded tail session on <round_dir>/events.jsonl, milestone kinds only; one folded line a minute
@@ -708,8 +708,8 @@ User: "revmux this branch"
 User: "fix the major one and run it again"
 → fix applied
 → "Preparing the round for the fixes…" → same subagent, handed task `tui-rework` and the fixes'
-  shortstat so it neither matches a task nor re-measures; opens 02-after-fix, copies profile.md
-  across and writes its own scope
+  shortstat so it neither matches a task nor re-measures; opens 02-after-fix and writes its own
+  scope; the profile is the repo's and revmux resolves it
 → revmux --task tui-rework --run 02-after-fix --no-tui
 → exit 0, nothing above threshold
 ```

--- a/plugins/codex/skills/revmux/SKILL.md
+++ b/plugins/codex/skills/revmux/SKILL.md
@@ -232,8 +232,8 @@ Hand it the resolved scope from Step 1 and this brief:
 >      document. Say that finding nothing is a valid answer, or the round reads as owing findings and
 >      manufactures them.
 >    - `profile` — **do not write it.** What it holds is about the repository rather than this round, so
->      it lives in `./.revmux/profile.md` and revmux gives every round the same one with nothing copied
->      forward. You see the diff and the file list, which is not enough to state a repo's conventions,
+>      it lives in `./.revmux/profile.md` and revmux gives every round without a non-empty override the same one
+>      with nothing copied forward. You see the diff and the file list, which is not enough to state a repo's conventions,
 >      and a generated file here wins over the project's and silently replaces it.
 >      Write it only when the user says this subject needs a different bar than the repo's.
 >    - `context` — optional. Ticket text, design notes, commit list. Its path is reported but the

--- a/plugins/codex/skills/revmux/SKILL.md
+++ b/plugins/codex/skills/revmux/SKILL.md
@@ -21,7 +21,7 @@ It does no scope detection, no git, no PR fetching, no source modification. This
 |---|---|
 | resolve what is under review | supervise, stagger, retry, degrade |
 | run git, gather context | compose and archive prompts |
-| write `scope.md`, `goal.md`, `profile.md`, `context/` | merge, dedupe, verify |
+| write `scope.md`, `goal.md`, `context/` | merge, dedupe, verify |
 | choose profile, lenses, flags | return findings on stdout |
 | read the JSON, present, fix, re-run | inject prior rounds |
 
@@ -116,6 +116,25 @@ brew install umputun/apps/revmux                   # macOS
 go install github.com/umputun/revmux/app@latest    # installs as 'app'; rename to 'revmux'
 git clone https://github.com/umputun/revmux.git && cd revmux && make install
 ```
+
+### Step 0.5: Offer the project profile, once per repository
+
+`revmux config`'s `paths.profile_fallback` is `./.revmux/profile.md` when the repo has one. Every round
+without its own `input/profile.md` inherits it, and nothing creates it — not `revmux init`, not this
+skill on its own. An empty field means every review here runs on generic calibration.
+
+When it is empty, say so in one line and offer to write it. **Only ever with the user's yes**, and never
+from the diff: read the project's own rules — `CLAUDE.md`, `AGENTS.md`, `CONTRIBUTING.md`, `docs/`, the
+linter config — and write what the software is, what a real failure looks like there, the blast radius,
+the reporting bar, and which conventions are deliberate. A profile guessed from one change is the thing
+this file exists to replace.
+
+Offer it once. If he declines, do not ask again in the session, and do not write a round-local
+`input/profile.md` instead — that wins over the project file and is exactly the substitution the round
+brief forbids.
+
+**Never on a fetched pull request or any tree that is not his**: `.revmux/` is checked-in configuration,
+so authoring one there commits a review standard to somebody else's repository.
 
 ### Step 1: Resolve what is being reviewed
 

--- a/plugins/codex/skills/revmux/references/invocation.md
+++ b/plugins/codex/skills/revmux/references/invocation.md
@@ -313,13 +313,20 @@ everything that survived verification.
 
 Two distinct roots, and conflating them is a common failure:
 
-- **the process working directory** governs the project config layer (`./.revmux/`) and the
-  `./.revmux/tasks` default for `--tasks-dir`
+- **the process working directory** governs the project config layer (`./.revmux/`), the project profile
+  `./.revmux/profile.md` inside it, and the `./.revmux/tasks` default for `--tasks-dir`
 - **`--workdir`** sets where the review subprocesses run and what `{{WORKDIR}}` expands to
 
 Reviewing a repository from outside it therefore means passing `--workdir`, `--tasks-dir` **and**
 `--config-dir` — otherwise the first resolves to the repo and the other two to wherever the caller
 happens to be standing.
+
+**`./.revmux/profile.md` is a fourth cwd-relative input and no flag relocates it.** Reviewing repo B from
+a checkout of repo A, a round with no `input/profile.md` of its own inherits **A's** project profile, so B
+is reviewed against A's bar. Write the round its own `input/profile.md` when reviewing from outside a
+tree, or check `revmux config`'s `paths.profile_fallback` first — the run itself is not silent about it,
+since the inherited bytes are archived as `prompts/input-profile.md` and labelled in the TUI, but that is
+after the fact.
 
 ## `.revmux/` in a repository is executable trust
 

--- a/plugins/codex/skills/revmux/references/invocation.md
+++ b/plugins/codex/skills/revmux/references/invocation.md
@@ -405,10 +405,10 @@ An empty list always means empty. If the tasks root could not be read the reason
 if one task's directory could not be read it is `rounds_error` on that entry, and a `--workdir` that would
 not resolve is `.paths.workdir_error`. Treat any of them as "unknown", never as "nothing is there".
 
-`.paths.profile_fallback` is `./.revmux/profile.md` when the repo has one: every round with no
+`.paths.profile_fallback` is `./.revmux/profile.md` when the repo has one: every round with no non-empty
 `input/profile.md` of its own inherits it, so do not write one per round. `.paths.profile_fallback_error`
-means that file will not resolve — a round that inherits it would refuse to start, while one carrying its
-own `input/profile.md` is unaffected, since the round file wins before the project one is read.
+means that file will not resolve — a round that inherits it would refuse to start, while one with a
+non-empty `input/profile.md` is unaffected, since the round file wins before the project one is read.
 `preflight.sh` does not gate on it: it runs before the round exists and cannot know which will win.
 
 ## `revmux new` — the only call that creates anything

--- a/plugins/codex/skills/revmux/references/invocation.md
+++ b/plugins/codex/skills/revmux/references/invocation.md
@@ -407,7 +407,9 @@ not resolve is `.paths.workdir_error`. Treat any of them as "unknown", never as 
 
 `.paths.profile_fallback` is `./.revmux/profile.md` when the repo has one: every round with no
 `input/profile.md` of its own inherits it, so do not write one per round. `.paths.profile_fallback_error`
-means that file will not resolve, and a review would refuse to start — `preflight.sh` already fails on it.
+means that file will not resolve — a round that inherits it would refuse to start, while one carrying its
+own `input/profile.md` is unaffected, since the round file wins before the project one is read.
+`preflight.sh` does not gate on it: it runs before the round exists and cannot know which will win.
 
 ## `revmux new` — the only call that creates anything
 

--- a/plugins/codex/skills/revmux/references/invocation.md
+++ b/plugins/codex/skills/revmux/references/invocation.md
@@ -405,6 +405,10 @@ An empty list always means empty. If the tasks root could not be read the reason
 if one task's directory could not be read it is `rounds_error` on that entry, and a `--workdir` that would
 not resolve is `.paths.workdir_error`. Treat any of them as "unknown", never as "nothing is there".
 
+`.paths.profile_fallback` is `./.revmux/profile.md` when the repo has one: every round with no
+`input/profile.md` of its own inherits it, so do not write one per round. `.paths.profile_fallback_error`
+means that file will not resolve, and a review would refuse to start — `preflight.sh` already fails on it.
+
 ## `revmux new` — the only call that creates anything
 
 ```bash

--- a/plugins/codex/skills/revmux/references/output.md
+++ b/plugins/codex/skills/revmux/references/output.md
@@ -156,7 +156,8 @@ Every artifact lands in the round directory — the `round_dir` `revmux new` rep
 ├── manifest.json             roster, prompt provenance + hashes, requested vs actual model, timings
 ├── prompts/
 │   ├── agents/               composed prompt per agent, post-substitution
-│   └── stages/               synthesis.md, verify-<group>.md
+│   ├── stages/               synthesis.md, verify-<group>.md
+│   └── input-profile.md      the project profile's bytes, when the round inherited one
 ├── stages/
 │   ├── 1-found.json
 │   ├── 2-synthesized.json
@@ -183,6 +184,7 @@ the recovery path when a run's stdout was lost.
 | did verify reject wrongly? | `stages/2-synthesized.json` vs `3-verified.json` |
 | what was this agent asked? | `prompts/agents/<name>.md` |
 | which lens text, from which layer? | `manifest.json` |
+| what calibrated this round? | `input/profile.md`, or `prompts/input-profile.md` when it inherited the project's |
 
 A failed archive write fails the run. The exception is a per-agent tee, which degrades that source.
 

--- a/plugins/codex/skills/revmux/references/task-dir.md
+++ b/plugins/codex/skills/revmux/references/task-dir.md
@@ -27,9 +27,9 @@ not name. The layout is revmux's own detail.
 `created` names what this call made, so a second round on an existing task reports `round_dir` and
 `input_dir` alone. `context` is reported but never created — create it only when filling it.
 
-**Each round carries its own scope, goal, profile and context.** Round 2 reviews the fixes for what
-round 1 found, so it gets its own `scope.md` at its own `input/` path; round 1's is left as the record
-of what round 1 reviewed.
+**Each round carries its own scope, goal and context.** A non-empty round profile is an optional override
+of the project profile. Round 2 reviews the fixes for what round 1 found, so it gets its own `scope.md`
+at its own `input/` path; round 1's is left as the record of what round 1 reviewed.
 
 ## Variables expand to paths, never contents
 
@@ -167,12 +167,13 @@ What kind of software this is and what counts as a real failure. Without it the 
 
 Do not write this file as a matter of course. What it describes — what the software is, what a real
 failure looks like, where the rules live — belongs to the repository rather than to one round, so it
-lives in `./.revmux/profile.md` and every round of every task inherits it with nothing copied forward.
+lives in `./.revmux/profile.md` and every round without a non-empty override inherits it with nothing
+copied forward.
 `revmux config` reports the resolved path as `paths.profile_fallback`.
 
 Write a round's own `input/profile.md` only when this subject genuinely needs a different bar than the
 repo's — a vendored or generated tree, a prototype, a subsystem the project profile does not describe.
-It wins outright when present, and the project file is then not read at all.
+A non-empty round file wins outright, and the project file is then not read at all.
 
 A round that inherits gets a copy of the bytes at `prompts/input-profile.md` inside the round, and
 `{{PROFILE}}` names that copy. The archive therefore records what actually calibrated the round even

--- a/plugins/codex/skills/revmux/references/task-dir.md
+++ b/plugins/codex/skills/revmux/references/task-dir.md
@@ -148,7 +148,7 @@ into defects.
 With no real goal — a mechanical cleanup, a dependency bump — omit the file rather than writing a
 placeholder.
 
-## profile.md — optional, reusable across the repo
+## profile.md — optional, a per-round override of the project's own
 
 What kind of software this is and what counts as a real failure. Without it the implicit bar is
 "production service with real traffic", wrong for a personal tool or a UI surface in both directions.
@@ -165,7 +165,18 @@ What kind of software this is and what counts as a real failure. Without it the 
 - **Which languages the change actually touches** — a Go repo's conventions are not the bar for a
   commit of shell and markdown
 
-Copy it forward into each round of a task; it is the one input that rarely changes between rounds.
+Do not write this file as a matter of course. What it describes — what the software is, what a real
+failure looks like, where the rules live — belongs to the repository rather than to one round, so it
+lives in `./.revmux/profile.md` and every round of every task inherits it with nothing copied forward.
+`revmux config` reports the resolved path as `paths.profile_fallback`.
+
+Write a round's own `input/profile.md` only when this subject genuinely needs a different bar than the
+repo's — a vendored or generated tree, a prototype, a subsystem the project profile does not describe.
+It wins outright when present, and the project file is then not read at all.
+
+A round that inherits gets a copy of the bytes at `prompts/input-profile.md` inside the round, and
+`{{PROFILE}}` names that copy. The archive therefore records what actually calibrated the round even
+after the project file changes.
 
 ## context/ — optional directory
 

--- a/plugins/codex/skills/revmux/references/triage.md
+++ b/plugins/codex/skills/revmux/references/triage.md
@@ -76,8 +76,9 @@ it this brief with every path already expanded:
 > 4. `goal` — the maintainer's framing when he gave one, **under 1000 characters**: what he wants out of
 >    the triage, and anything he has already settled. Omit the file when he said nothing rather than
 >    inventing a frame.
-> 5. `profile` — the project's own conventions, as in Step 2. Copy the previous round's when a round has
->    one.
+> 5. `profile` — **do not write it.** It holds the project's own conventions, which revmux resolves from
+>    `./.revmux/profile.md` for every round. Write one only when the user says this item needs a
+>    different bar than the repo's.
 > 6. `context/` — one file each: the item's body in full, its whole thread in order with each comment's
 >    author, the author's own history from the command above, and any item the thread links. Curate:
 >    every file is a tool call an agent may spend.

--- a/plugins/codex/skills/revmux/scripts/preflight.sh
+++ b/plugins/codex/skills/revmux/scripts/preflight.sh
@@ -98,14 +98,6 @@ cfg=$(revmux config 2>/dev/null) || {
 }
 
 if command -v jq >/dev/null 2>&1; then
-    # a project profile that will not resolve fails the review at load, so reporting ok here would
-    # send the caller into a run that cannot start
-    profile_err=$(printf '%s' "$cfg" | jq -r '.paths.profile_fallback_error // empty')
-    if [ -n "$profile_err" ]; then
-        fail "project profile: UNREADABLE - $profile_err"
-        echo "hint: fix or remove ./.revmux/profile.md"
-    fi
-
     if [ -n "$profile" ]; then
         known=$(printf '%s' "$cfg" | jq -r --arg p "$profile" '[.profiles[].name] | index($p) // "null"')
         if [ "$known" = "null" ]; then

--- a/plugins/codex/skills/revmux/scripts/preflight.sh
+++ b/plugins/codex/skills/revmux/scripts/preflight.sh
@@ -98,6 +98,14 @@ cfg=$(revmux config 2>/dev/null) || {
 }
 
 if command -v jq >/dev/null 2>&1; then
+    # a project profile that will not resolve fails the review at load, so reporting ok here would
+    # send the caller into a run that cannot start
+    profile_err=$(printf '%s' "$cfg" | jq -r '.paths.profile_fallback_error // empty')
+    if [ -n "$profile_err" ]; then
+        fail "project profile: UNREADABLE - $profile_err"
+        echo "hint: fix or remove ./.revmux/profile.md"
+    fi
+
     if [ -n "$profile" ]; then
         known=$(printf '%s' "$cfg" | jq -r --arg p "$profile" '[.profiles[].name] | index($p) // "null"')
         if [ "$known" = "null" ]; then

--- a/site/docs.html
+++ b/site/docs.html
@@ -364,7 +364,7 @@ revmux --task pr-123 --run 02-after-fix &gt; findings.json</pre>
 │   ├── input/                    caller-written; the only channel review context travels through
 │   │   ├── scope.md              {{SCOPE}}    required; missing or empty is a load-time error
 │   │   ├── goal.md               {{GOAL}}     optional
-│   │   ├── profile.md            {{PROFILE}}  optional, the project's own conventions
+│   │   ├── profile.md            {{PROFILE}}  optional; overrides ./.revmux/profile.md
 │   │   └── context/              {{CONTEXT}}  optional: ticket text, design notes, spec excerpts
 │   └── ...                       revmux-written artifacts, see the run archive
 └── 02-after-fix/                 the next round, with its own input/</pre>
@@ -382,8 +382,17 @@ revmux --task pr-123 --run 02-after-fix &gt; findings.json</pre>
         </p>
         <p>
           There are no <code>--goal</code>, <code>--goal-file</code>, <code>--profile-file</code> or
-          <code>--context-file</code> flags. One mechanism, no precedence rules, and nothing for revmux to
-          author.
+          <code>--context-file</code> flags. One mechanism, and nothing for revmux to author.
+        </p>
+        <p>
+          <code>profile.md</code> is the one file with a layer under it, because what it says is true of the
+          repository rather than of one round. Put it in <code>./.revmux/profile.md</code> and every round of
+          every task inherits it — <a href="#config"><code>revmux config</code></a> reports the resolved path
+          as <code>paths.profile_fallback</code>, and the bytes are copied into each round as
+          <code>prompts/input-profile.md</code> so the archive records what actually calibrated it. A round's
+          own <code>input/profile.md</code> wins outright, and is worth writing only to hold that subject to a
+          different bar than the repo's. The user layer is never searched for it: calibration spanning
+          repositories describes none of them.
         </p>
         <p>
           <code>--run</code> has no default: the round holds your own context, so revmux cannot name one you
@@ -493,7 +502,6 @@ Reviewing the token exchange path after the provider swap.</pre>
         </div>
         <pre class="code">~/.config/revmux/
 ├── config                    INI, runtime knobs only
-├── profile.md                project layer only: what this repo is, and its reporting bar
 ├── prompts/
 │   ├── profiles/
 │   │   ├── comprehensive.md  roster front matter + shared preamble + severity bar
@@ -504,7 +512,11 @@ Reviewing the token exchange path after the provider swap.</pre>
 └── lenses/
     ├── bugs.md  impl.md  architecture.md
     ├── quality.md  docs.md  tests.md  comments.md  adversarial.md
-    └── grounding.md  precedent.md  thesis.md  antithesis.md  cost.md</pre>
+    └── grounding.md  precedent.md  thesis.md  antithesis.md  cost.md
+
+./.revmux/                    the project layer: the same shape, plus one file of its own
+└── profile.md                what this repo is and its reporting bar, inherited by every round
+                              here only — the user layer is never searched for it</pre>
         <p>
           <code>--config-dir</code> relocates the user layer. <a href="#init"><code>revmux init</code></a>
           materializes <code>./.revmux/</code> from whatever resolved, and

--- a/site/docs.html
+++ b/site/docs.html
@@ -528,7 +528,10 @@ Reviewing the token exchange path after the provider swap.</pre>
           Paths resolve against the <strong>process working directory</strong>: the project config layer, and
           <code>--tasks-dir</code>'s <code>./.revmux/tasks</code> default. <code>--workdir</code> is separate,
           setting where the subprocesses run and what <code>{{WORKDIR}}</code> expands to. Reviewing a repository
-          from outside it means passing <code>--config-dir</code> and <code>--tasks-dir</code> as well.
+          from outside it means passing <code>--config-dir</code> and <code>--tasks-dir</code> as well, and
+          writing the round its own <code>input/profile.md</code> — <code>./.revmux/profile.md</code> is
+          cwd-relative too and no flag relocates it, so a round without one inherits the calibration of
+          whatever project you are standing in.
         </p>
 
         <h2 id="profiles">Profiles <a class="anchor" href="#profiles">#</a></h2>

--- a/site/docs.html
+++ b/site/docs.html
@@ -361,7 +361,7 @@ revmux --task pr-123 --run 02-after-fix &gt; findings.json</pre>
         <pre class="code">&lt;tasks-dir&gt;/pr-123/               a task: one subject, reviewed over as many rounds as it takes
 ├── task.md                       optional; front matter identifying the task
 ├── 01-initial/                   a round
-│   ├── input/                    caller-written; the only channel review context travels through
+│   ├── input/                    caller-written; the only channel this round's own context travels through
 │   │   ├── scope.md              {{SCOPE}}    required; missing or empty is a load-time error
 │   │   ├── goal.md               {{GOAL}}     optional
 │   │   ├── profile.md            {{PROFILE}}  optional; overrides ./.revmux/profile.md
@@ -1076,6 +1076,12 @@ receives, including what counts as critical, major and minor here.</pre>
           completion, so neither a directory prepared but not yet reviewed nor a round whose review was
           interrupted is one. An empty list always means empty: a tasks root that could not be read is reported
           as <code>paths.tasks_error</code>, and nothing that failed is reported as nothing being there.
+        </p>
+        <p>
+          <code>paths.profile_fallback</code> is the resolved <code>./.revmux/profile.md</code>, so a caller can
+          tell that a round it leaves without a profile will still be calibrated. The same rule applies here:
+          one that will not resolve is <code>paths.profile_fallback_error</code> rather than a missing
+          fallback, because the review would refuse that invocation.
         </p>
 
         <h2 id="init">revmux init <a class="anchor" href="#init">#</a></h2>

--- a/site/docs.html
+++ b/site/docs.html
@@ -364,7 +364,7 @@ revmux --task pr-123 --run 02-after-fix &gt; findings.json</pre>
 │   ├── input/                    caller-written; the only channel this round's own context travels through
 │   │   ├── scope.md              {{SCOPE}}    required; missing or empty is a load-time error
 │   │   ├── goal.md               {{GOAL}}     optional
-│   │   ├── profile.md            {{PROFILE}}  optional; overrides ./.revmux/profile.md
+│   │   ├── profile.md            {{PROFILE}}  optional; non-empty overrides ./.revmux/profile.md
 │   │   └── context/              {{CONTEXT}}  optional: ticket text, design notes, spec excerpts
 │   └── ...                       revmux-written artifacts, see the run archive
 └── 02-after-fix/                 the next round, with its own input/</pre>
@@ -386,12 +386,12 @@ revmux --task pr-123 --run 02-after-fix &gt; findings.json</pre>
         </p>
         <p>
           <code>profile.md</code> is the one file with a layer under it, because what it says is true of the
-          repository rather than of one round. Put it in <code>./.revmux/profile.md</code> and every round of
-          every task inherits it — <a href="#config"><code>revmux config</code></a> reports the resolved path
+          repository rather than of one round. Put it in <code>./.revmux/profile.md</code> and every round
+          without a non-empty override inherits it — <a href="#config"><code>revmux config</code></a> reports the resolved path
           as <code>paths.profile_fallback</code>, and the bytes are copied into each round as
           <code>prompts/input-profile.md</code> so the archive records what actually calibrated it. A round's
-          own <code>input/profile.md</code> wins outright, and is worth writing only to hold that subject to a
-          different bar than the repo's. The user layer is never searched for it: calibration spanning
+          non-empty <code>input/profile.md</code> wins outright, and is worth writing only to hold that subject
+          to a different bar than the repo's. The user layer is never searched for it: calibration spanning
           repositories describes none of them.
         </p>
         <p>
@@ -1079,9 +1079,9 @@ receives, including what counts as critical, major and minor here.</pre>
         </p>
         <p>
           <code>paths.profile_fallback</code> is the resolved <code>./.revmux/profile.md</code>, so a caller can
-          tell that a round it leaves without a profile will still be calibrated. The same rule applies here:
+          tell that a round it leaves without a non-empty profile will still be calibrated. The same rule applies here:
           one that will not resolve is <code>paths.profile_fallback_error</code> rather than a missing
-          fallback, because a round that inherited it would refuse to start. A round carrying its own
+          fallback, because a round that inherited it would refuse to start. A round with a non-empty
           <code>input/profile.md</code> is unaffected — that file wins before the project one is read.
         </p>
 

--- a/site/docs.html
+++ b/site/docs.html
@@ -1081,7 +1081,8 @@ receives, including what counts as critical, major and minor here.</pre>
           <code>paths.profile_fallback</code> is the resolved <code>./.revmux/profile.md</code>, so a caller can
           tell that a round it leaves without a profile will still be calibrated. The same rule applies here:
           one that will not resolve is <code>paths.profile_fallback_error</code> rather than a missing
-          fallback, because the review would refuse that invocation.
+          fallback, because a round that inherited it would refuse to start. A round carrying its own
+          <code>input/profile.md</code> is unaffected — that file wins before the project one is read.
         </p>
 
         <h2 id="init">revmux init <a class="anchor" href="#init">#</a></h2>

--- a/site/docs.html
+++ b/site/docs.html
@@ -493,6 +493,7 @@ Reviewing the token exchange path after the provider swap.</pre>
         </div>
         <pre class="code">~/.config/revmux/
 ├── config                    INI, runtime knobs only
+├── profile.md                project layer only: what this repo is, and its reporting bar
 ├── prompts/
 │   ├── profiles/
 │   │   ├── comprehensive.md  roster front matter + shared preamble + severity bar
@@ -866,10 +867,11 @@ receives, including what counts as critical, major and minor here.</pre>
 │   ├── agents/               composed prompt per agent, post-substitution: the bytes the model saw
 │   │   ├── bugs+impl.md
 │   │   └── codex.md
-│   └── stages/               separate from agents/ so an agent named `verify` cannot collide
-│       ├── synthesis.md
-│       ├── verify-app-executor.md      one per group, directories by default
-│       └── verify-app-pipeline.md
+│   ├── stages/               separate from agents/ so an agent named `verify` cannot collide
+│   │   ├── synthesis.md
+│   │   ├── verify-app-executor.md      one per group, directories by default
+│   │   └── verify-app-pipeline.md
+│   └── input-profile.md      the project profile's bytes, when this round inherited one
 ├── stages/                   a skipped stage writes no snapshot
 │   ├── 1-found.json          findings as the find stage left them
 │   ├── 2-synthesized.json

--- a/site/index.html
+++ b/site/index.html
@@ -475,7 +475,7 @@
 │   ├── input/              caller-written, the only channel context travels through
 │   │   ├── scope.md        {{SCOPE}}    required
 │   │   ├── goal.md         {{GOAL}}     optional
-│   │   ├── profile.md      {{PROFILE}}  optional, the project's own conventions
+│   │   ├── profile.md      {{PROFILE}}  optional; overrides ./.revmux/profile.md
 │   │   └── context/        {{CONTEXT}}  optional, any number of files
 │   └── ...                 revmux-written artifacts
 └── <b>02-after-fix/</b>           the next round, with its own input/</pre

--- a/site/index.html
+++ b/site/index.html
@@ -475,7 +475,7 @@
 │   ├── input/              caller-written, the only channel this round's own context travels through
 │   │   ├── scope.md        {{SCOPE}}    required
 │   │   ├── goal.md         {{GOAL}}     optional
-│   │   ├── profile.md      {{PROFILE}}  optional; overrides ./.revmux/profile.md
+│   │   ├── profile.md      {{PROFILE}}  optional; non-empty overrides ./.revmux/profile.md
 │   │   └── context/        {{CONTEXT}}  optional, any number of files
 │   └── ...                 revmux-written artifacts
 └── <b>02-after-fix/</b>           the next round, with its own input/</pre

--- a/site/index.html
+++ b/site/index.html
@@ -548,7 +548,8 @@ EOF
 ├── manifest.json       roster, prompt provenance and hashes, requested vs actual model
 ├── prompts/
 │   ├── agents/         the composed prompt each agent received, post-substitution
-│   └── stages/         synthesis.md, verify-app-pipeline.md, ...
+│   ├── stages/         synthesis.md, verify-app-pipeline.md, ...
+│   └── input-profile.md  the project profile's bytes, when the round inherited one
 ├── stages/             1-found.json, 2-synthesized.json, 3-verified.json
 ├── events.jsonl        revmux's own decisions: stalls, retries, degrades, transitions
 ├── agents/             verbatim tees, one file per attempt

--- a/site/index.html
+++ b/site/index.html
@@ -472,7 +472,7 @@
 <b>.revmux/tasks/pr-123/</b>        a task: one subject, as many rounds as it takes
 ├── task.md                 optional anchors: description, url, branch, base
 ├── <b>01-initial/</b>             a round
-│   ├── input/              caller-written, the only channel context travels through
+│   ├── input/              caller-written, the only channel this round's own context travels through
 │   │   ├── scope.md        {{SCOPE}}    required
 │   │   ├── goal.md         {{GOAL}}     optional
 │   │   ├── profile.md      {{PROFILE}}  optional; overrides ./.revmux/profile.md

--- a/site/reference.html
+++ b/site/reference.html
@@ -389,7 +389,7 @@ claude/opus:hgih         <span class="c-crimson">refused: not an effort</span></
             <tbody>
               <tr><td>{{SCOPE}}</td><td class="prose">path of the round's <code>input/scope.md</code></td><td class="prose">any prompt</td></tr>
               <tr><td>{{GOAL}}</td><td class="prose">path of <code>input/goal.md</code>, or <code>none provided</code></td><td class="prose">any prompt</td></tr>
-              <tr><td>{{PROFILE}}</td><td class="prose">path of <code>input/profile.md</code>; falling back to the round's copy of <code>./.revmux/profile.md</code> at <code>prompts/input-profile.md</code>, or <code>none provided</code></td><td class="prose">any prompt</td></tr>
+              <tr><td>{{PROFILE}}</td><td class="prose">path of a non-empty <code>input/profile.md</code>; falling back to the round's copy of <code>./.revmux/profile.md</code> at <code>prompts/input-profile.md</code>, or <code>none provided</code></td><td class="prose">any prompt</td></tr>
               <tr><td>{{CONTEXT}}</td><td class="prose">path of <code>input/context/</code>, or <code>none provided</code></td><td class="prose">any prompt</td></tr>
               <tr><td>{{WORKDIR}}</td><td class="prose">the directory the subprocesses run in</td><td class="prose">any prompt</td></tr>
               <tr><td>{{FINDINGS}}</td><td class="prose">the findings that stage receives</td><td class="prose">synthesis, verify</td></tr>

--- a/site/reference.html
+++ b/site/reference.html
@@ -389,7 +389,7 @@ claude/opus:hgih         <span class="c-crimson">refused: not an effort</span></
             <tbody>
               <tr><td>{{SCOPE}}</td><td class="prose">path of the round's <code>input/scope.md</code></td><td class="prose">any prompt</td></tr>
               <tr><td>{{GOAL}}</td><td class="prose">path of <code>input/goal.md</code>, or <code>none provided</code></td><td class="prose">any prompt</td></tr>
-              <tr><td>{{PROFILE}}</td><td class="prose">path of <code>input/profile.md</code>, or <code>none provided</code></td><td class="prose">any prompt</td></tr>
+              <tr><td>{{PROFILE}}</td><td class="prose">path of <code>input/profile.md</code>; falling back to the round's copy of <code>./.revmux/profile.md</code> at <code>prompts/input-profile.md</code>, or <code>none provided</code></td><td class="prose">any prompt</td></tr>
               <tr><td>{{CONTEXT}}</td><td class="prose">path of <code>input/context/</code>, or <code>none provided</code></td><td class="prose">any prompt</td></tr>
               <tr><td>{{WORKDIR}}</td><td class="prose">the directory the subprocesses run in</td><td class="prose">any prompt</td></tr>
               <tr><td>{{FINDINGS}}</td><td class="prose">the findings that stage receives</td><td class="prose">synthesis, verify</td></tr>

--- a/site/reference.html
+++ b/site/reference.html
@@ -504,6 +504,7 @@ claude/opus:hgih         <span class="c-crimson">refused: not an effort</span></
 │                      so it doubles as the marker claiming the round
 ├── prompts/agents/    the composed prompt each agent received, post-substitution
 ├── prompts/stages/    synthesis and one file per verify group
+├── prompts/input-profile.md  the project profile's bytes, when the round inherited one
 ├── stages/            1-found.json, 2-synthesized.json, 3-verified.json
 ├── events.jsonl       stalls, retries, degrades, stage transitions
 ├── agents/            verbatim tees: &lt;agent&gt;.jsonl, &lt;agent&gt;.log, &lt;agent&gt;.retry.jsonl


### PR DESCRIPTION
A round with no `input/profile.md` of its own now inherits `./.revmux/profile.md`, the repo-wide default. What that file says is true of the repository rather than of one round, so making every round carry a copy meant round 01 of each task ran on whatever the caller generated that time, and different tasks in one repo were reviewed against quietly different bars.

Precedence is `<round>/input/profile.md` > `./.revmux/profile.md` > `none provided`. Absent and empty mean the same thing in both places. The project layer only: a `~/.config/revmux/profile.md` spanning repositories describes none of them.

The inherited bytes are copied into the round as `prompts/input-profile.md` and `{{PROFILE}}` names that copy. The variable expands to a path, so a round pointed at the project file would carry no record of what calibrated it once that file changed. Nothing is written into `input/`, which is the caller's: a snapshot placed there would be read as an explicit round-local override on the next attempt, and the authored project file would stop applying with nothing saying so.

Resolution keys on `projectDir()` rather than `o.layers.project`, which the `--config-dir ./.revmux` collapse empties for provenance reasons while the file stays on disk. `revmux config` reports the same resolution as `paths.profile_fallback`, with `paths.profile_fallback_error` when it will not resolve. That field is observability rather than a gate: whether it matters depends on the round, and nothing repo-global can know that before the round exists.

Materialization runs at the top of `review`, after the cancellation check and before the renderer is built, since the TUI's input snapshot is taken there and the agents read the path later. That placement preserves the reclaim window: `Pipeline.Run` opens `events.jsonl` as its first act, so writing the snapshot at claim time instead would burn a round on any interruption at all.

Both shipped skill trees stop generating a profile per round. The compose step sees a diff and a file list, which cannot state a repo's conventions, and a generated file wins over the project's. A new step offers once, and only with the user's yes, to write the project profile from the repository's own rules.

One gap, documented rather than closed: `./.revmux/profile.md` is cwd-relative and no flag relocates it, so reviewing one repo from a checkout of another inherits the caller's bar. An unattended caller that needs a hard gate on calibration still needs its own.

Related to #10
