### PR TITLE
feat(executor): run claude with --strict-mcp-config by default

### DIFF
--- a/.claude-plugin/skills/revmux/references/invocation.md
+++ b/.claude-plugin/skills/revmux/references/invocation.md
@@ -579,8 +579,7 @@ is always stripped — a `claude` child refuses to start when it believes it is 
 is exactly the situation when an agent invokes revmux.
 
 `claude` runs with `--strict-mcp-config`, so a review boots no MCP servers even when the workdir sits
-inside a project that configures them; `--preserve-mcp` turns that off. Codex has no equivalent single
-switch, so a codex entry still loads whatever `~/.codex/config.toml` defines.
+inside a project that configures them; `--preserve-mcp` turns that off.
 
 Agent processes start in their own session, so the terminal never signals them directly; revmux tears
 each process group down itself rather than leaving model CLIs running unsupervised after it exits.

--- a/.claude-plugin/skills/revmux/references/invocation.md
+++ b/.claude-plugin/skills/revmux/references/invocation.md
@@ -578,6 +578,10 @@ subscription auth; `--preserve-anthropic-api-key` passes it through for key-base
 is always stripped — a `claude` child refuses to start when it believes it is a nested session, which
 is exactly the situation when an agent invokes revmux.
 
+`claude` runs with `--strict-mcp-config`, so a review boots no MCP servers even when the workdir sits
+inside a project that configures them; `--preserve-mcp` turns that off. Codex has no equivalent single
+switch, so a codex entry still loads whatever `~/.codex/config.toml` defines.
+
 Agent processes start in their own session, so the terminal never signals them directly; revmux tears
 each process group down itself rather than leaving model CLIs running unsupervised after it exits.
 
@@ -595,6 +599,7 @@ each process group down itself rather than leaving model CLIs running unsupervis
 | `--no-tui` | | disable the terminal UI |
 | `--markdown` | | write the report as markdown instead of JSON |
 | `--preserve-anthropic-api-key` | | pass `ANTHROPIC_API_KEY` to the model CLIs |
+| `--preserve-mcp` | | let the model CLIs load MCP servers from the caller's config |
 | `--config-dir=<dir>` | `~/.config/revmux` | directory holding the config file and the prompt tree |
 | `--init` | | materialize the resolved config and prompt tree into `./.revmux/` |
 | `--dump-defaults=<dir>` | | extract the embedded prompt tree into a directory |

--- a/.claude/rules/executor.md
+++ b/.claude/rules/executor.md
@@ -106,10 +106,9 @@ claude --print --output-format stream-json --verbose
   under roughly 130 bytes of JSON wrapper per chunk.
 - **`--strict-mcp-config` by default: a review boots no MCP servers.**
   claude resolves `.mcp.json` by walking up from the workdir, so a review worktree inside a configured
-  repo inherits the caller's whole roster — measured at 12 project servers plus 3 plugin ones, 161 tools
-  where a strict run has 31, and a server whose OAuth was never completed opens a browser tab on every
-  spawn. A finder reads a diff and returns findings; none of that roster is work it can use.
-  Unlike `--bare` this keeps project-instruction discovery. `--preserve-mcp` is the escape hatch.
+  repo inherits the caller's whole roster — 161 tools against 31 measured on one monorepo, and a server
+  whose OAuth was never completed opens a browser tab per spawn. Unlike `--bare` it keeps
+  project-instruction discovery. `--preserve-mcp` is the escape hatch.
 - The prompt goes in on **stdin**, never as an argv positional.
   Windows `cmd.exe` caps a command line at 8191 characters and a composed lens prompt blows past that instantly.
 
@@ -321,10 +320,6 @@ Codex is a peer executor, not a special case in the pipeline — but the executo
   prompt quoted — a lens body, a finding describing an error — as the failure,
   and hands `classify` a line that can carry a limit pattern the run never hit.
 - `--sandbox read-only` always. revmux never lets an agent write.
-- **Codex has no single switch that disables its MCP servers, so `--preserve-mcp` is claude-only.**
-  `-c mcp_servers={}` merges with the config rather than replacing it — measured: `codex mcp list --json`
-  returns the same servers with and without it. Turning them off needs one
-  `-c mcp_servers.<name>.enabled=false` per server, which means reading the list first.
 
 ### Error and limit patterns
 

--- a/.claude/rules/executor.md
+++ b/.claude/rules/executor.md
@@ -63,6 +63,7 @@ claude --print --output-format stream-json --verbose
        --disable-slash-commands
        --no-session-persistence
        --include-partial-messages
+       --strict-mcp-config
        --json-schema <findings schema>
        < prompt
 ```
@@ -103,6 +104,12 @@ claude --print --output-format stream-json --verbose
   plaintext reaching the tee through this flag alone — the assistant blocks arrive with `thinking` empty
   and only a `signature` — and the rest is every byte of text and tool input carried a second time
   under roughly 130 bytes of JSON wrapper per chunk.
+- **`--strict-mcp-config` by default: a review boots no MCP servers.**
+  claude resolves `.mcp.json` by walking up from the workdir, so a review worktree inside a configured
+  repo inherits the caller's whole roster — measured at 12 project servers plus 3 plugin ones, 161 tools
+  where a strict run has 31, and a server whose OAuth was never completed opens a browser tab on every
+  spawn. A finder reads a diff and returns findings; none of that roster is work it can use.
+  Unlike `--bare` this keeps project-instruction discovery. `--preserve-mcp` is the escape hatch.
 - The prompt goes in on **stdin**, never as an argv positional.
   Windows `cmd.exe` caps a command line at 8191 characters and a composed lens prompt blows past that instantly.
 
@@ -314,6 +321,10 @@ Codex is a peer executor, not a special case in the pipeline — but the executo
   prompt quoted — a lens body, a finding describing an error — as the failure,
   and hands `classify` a line that can carry a limit pattern the run never hit.
 - `--sandbox read-only` always. revmux never lets an agent write.
+- **Codex has no single switch that disables its MCP servers, so `--preserve-mcp` is claude-only.**
+  `-c mcp_servers={}` merges with the config rather than replacing it — measured: `codex mcp list --json`
+  returns the same servers with and without it. Turning them off needs one
+  `-c mcp_servers.<name>.enabled=false` per server, which means reading the list first.
 
 ### Error and limit patterns
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ profile and any invocation.
 `ANTHROPIC_API_KEY` is stripped from the child environment by default so `claude` uses interactive
 subscription auth; pass `--preserve-anthropic-api-key` if you authenticate by key.
 
+`claude` runs with `--strict-mcp-config`, so a review boots no MCP servers even when the working directory
+sits inside a project that configures them. Pass `--preserve-mcp` if a lens needs one.
+
 ## Quick start
 
 `revmux new` creates the round and prints every path you write to, so nothing constructs a path by hand:

--- a/app/config.go
+++ b/app/config.go
@@ -55,6 +55,7 @@ type options struct {
 	NoTUI          bool     `long:"no-tui" no-ini:"true" description:"disable the terminal UI"`
 	Markdown       bool     `long:"markdown" no-ini:"true" description:"write the report as markdown instead of JSON"`
 	PreserveAPIKey bool     `long:"preserve-anthropic-api-key" no-ini:"true" description:"pass ANTHROPIC_API_KEY to the model CLIs"`
+	PreserveMCP    bool     `long:"preserve-mcp" no-ini:"true" description:"let the model CLIs load MCP servers from the caller's config"`
 
 	IdleTimeout   time.Duration `long:"idle-timeout" ini-name:"idle-timeout" default:"2m" description:"kill and retry an agent after this long with no output"`
 	HardTimeout   time.Duration `long:"hard-timeout" ini-name:"hard-timeout" default:"20m" description:"kill an agent after this long, per attempt"`
@@ -310,6 +311,7 @@ func (o options) executorOpts(rc reviewContext, clk executor.Clock) executor.Opt
 		HardTimeout:    o.HardTimeout,
 		WorkDir:        rc.WorkDir,
 		PreserveAPIKey: o.PreserveAPIKey,
+		PreserveMCP:    o.PreserveMCP,
 		Clock:          clk,
 	}
 }

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -566,11 +566,11 @@ func TestOptions_checkNames(t *testing.T) {
 
 func TestOptions_executorOpts(t *testing.T) {
 	clk := &mocks.ClockMock{}
-	o := options{IdleTimeout: time.Minute, HardTimeout: time.Hour, PreserveAPIKey: true, WorkDir: "/ignored"}
+	o := options{IdleTimeout: time.Minute, HardTimeout: time.Hour, PreserveAPIKey: true, PreserveMCP: true, WorkDir: "/ignored"}
 
 	got := o.executorOpts(reviewContext{WorkDir: "/resolved"}, clk)
 	assert.Equal(t, executor.Opts{IdleTimeout: time.Minute, HardTimeout: time.Hour,
-		WorkDir: "/resolved", PreserveAPIKey: true, Clock: clk}, got,
+		WorkDir: "/resolved", PreserveAPIKey: true, PreserveMCP: true, Clock: clk}, got,
 		"the subprocess runs where {{WORKDIR}} points, never where the raw flag does")
 }
 

--- a/app/executor/claude.go
+++ b/app/executor/claude.go
@@ -75,11 +75,6 @@ func (c *Claude) args(req Request) []string {
 		"--no-session-persistence",
 		"--include-partial-messages",
 	}
-	// a finder reads a diff and returns findings, so the caller's MCP servers cost startup time and tool
-	// schemas for nothing. claude resolves .mcp.json by walking up from the workdir, so a review worktree
-	// inside a configured repo inherits the whole roster, including any server whose auth was never
-	// completed, which opens a browser tab on every spawn. --strict-mcp-config with no --mcp-config leaves
-	// zero servers and, unlike --bare, still discovers project instructions.
 	if !c.opts.PreserveMCP {
 		argv = append(argv, "--strict-mcp-config")
 	}

--- a/app/executor/claude.go
+++ b/app/executor/claude.go
@@ -75,6 +75,14 @@ func (c *Claude) args(req Request) []string {
 		"--no-session-persistence",
 		"--include-partial-messages",
 	}
+	// a finder reads a diff and returns findings, so the caller's MCP servers cost startup time and tool
+	// schemas for nothing. claude resolves .mcp.json by walking up from the workdir, so a review worktree
+	// inside a configured repo inherits the whole roster, including any server whose auth was never
+	// completed, which opens a browser tab on every spawn. --strict-mcp-config with no --mcp-config leaves
+	// zero servers and, unlike --bare, still discovers project instructions.
+	if !c.opts.PreserveMCP {
+		argv = append(argv, "--strict-mcp-config")
+	}
 	if req.Model != "" {
 		argv = append(argv, "--model", req.Model)
 	}

--- a/app/executor/claude_test.go
+++ b/app/executor/claude_test.go
@@ -106,6 +106,7 @@ func TestClaude_args(t *testing.T) {
 		"--disable-slash-commands",
 		"--no-session-persistence",
 		"--include-partial-messages",
+		"--strict-mcp-config",
 		"--model", "opus",
 		"--effort", "high",
 		"--json-schema", `{"type":"object"}`,
@@ -129,6 +130,18 @@ func TestClaude_args_optionalFlagsOmitted(t *testing.T) {
 	assert.Contains(t, args, "--disable-slash-commands")
 	assert.Contains(t, args, "--include-partial-messages",
 		"the watchdog's only liveness while the model composes a large StructuredOutput call")
+}
+
+func TestClaude_args_preserveMCP(t *testing.T) {
+	path := writeFixture(t, cleanCapture(t))
+	runner := fakeRunner("emit", path)
+	c := executor.NewClaude(runner, executor.Opts{PreserveMCP: true})
+
+	_, err := c.Run(context.Background(), executor.Request{Prompt: "x"}, discardSink())
+	require.NoError(t, err)
+
+	assert.NotContains(t, runner.CommandCalls()[0].Args, "--strict-mcp-config",
+		"the escape hatch is the only way a finder reaches an MCP server")
 }
 
 func TestClaude_Run_clean(t *testing.T) {

--- a/app/executor/executor.go
+++ b/app/executor/executor.go
@@ -69,6 +69,7 @@ type Opts struct {
 	HardTimeout    time.Duration
 	WorkDir        string
 	PreserveAPIKey bool
+	PreserveMCP    bool
 	Clock          Clock
 }
 

--- a/plugins/codex/skills/revmux/references/invocation.md
+++ b/plugins/codex/skills/revmux/references/invocation.md
@@ -579,8 +579,7 @@ is always stripped — a `claude` child refuses to start when it believes it is 
 is exactly the situation when an agent invokes revmux.
 
 `claude` runs with `--strict-mcp-config`, so a review boots no MCP servers even when the workdir sits
-inside a project that configures them; `--preserve-mcp` turns that off. Codex has no equivalent single
-switch, so a codex entry still loads whatever `~/.codex/config.toml` defines.
+inside a project that configures them; `--preserve-mcp` turns that off.
 
 Agent processes start in their own session, so the terminal never signals them directly; revmux tears
 each process group down itself rather than leaving model CLIs running unsupervised after it exits.

--- a/plugins/codex/skills/revmux/references/invocation.md
+++ b/plugins/codex/skills/revmux/references/invocation.md
@@ -578,6 +578,10 @@ subscription auth; `--preserve-anthropic-api-key` passes it through for key-base
 is always stripped — a `claude` child refuses to start when it believes it is a nested session, which
 is exactly the situation when an agent invokes revmux.
 
+`claude` runs with `--strict-mcp-config`, so a review boots no MCP servers even when the workdir sits
+inside a project that configures them; `--preserve-mcp` turns that off. Codex has no equivalent single
+switch, so a codex entry still loads whatever `~/.codex/config.toml` defines.
+
 Agent processes start in their own session, so the terminal never signals them directly; revmux tears
 each process group down itself rather than leaving model CLIs running unsupervised after it exits.
 
@@ -595,6 +599,7 @@ each process group down itself rather than leaving model CLIs running unsupervis
 | `--no-tui` | | disable the terminal UI |
 | `--markdown` | | write the report as markdown instead of JSON |
 | `--preserve-anthropic-api-key` | | pass `ANTHROPIC_API_KEY` to the model CLIs |
+| `--preserve-mcp` | | let the model CLIs load MCP servers from the caller's config |
 | `--config-dir=<dir>` | `~/.config/revmux` | directory holding the config file and the prompt tree |
 | `--init` | | materialize the resolved config and prompt tree into `./.revmux/` |
 | `--dump-defaults=<dir>` | | extract the embedded prompt tree into a directory |

--- a/site/docs.html
+++ b/site/docs.html
@@ -239,6 +239,11 @@ make install      <span class="c-dim"># and symlinks it to /usr/local/bin/revmux
           always stripped, since a <code>claude</code> child refuses to start when it thinks it is a nested
           session.
         </p>
+        <p>
+          <code>claude</code> runs with <code>--strict-mcp-config</code>, so a review boots no MCP servers
+          even when the working directory sits inside a project that configures them. Pass
+          <code>--preserve-mcp</code> if a lens needs one.
+        </p>
 
         <h2 id="quick-start">Quick start <a class="anchor" href="#quick-start">#</a></h2>
         <p>

--- a/site/reference.html
+++ b/site/reference.html
@@ -139,6 +139,7 @@
               <tr><td>--no-tui</td><td></td><td class="prose">disable the terminal UI</td></tr>
               <tr><td>--markdown</td><td></td><td class="prose">write the report as markdown instead of JSON</td></tr>
               <tr><td>--preserve-anthropic-api-key</td><td></td><td class="prose">pass <code>ANTHROPIC_API_KEY</code> to the model CLIs</td></tr>
+              <tr><td>--preserve-mcp</td><td></td><td class="prose">let the model CLIs load MCP servers from the caller's config</td></tr>
               <tr><td>--idle-timeout=&lt;d&gt;</td><td>2m</td><td class="prose">kill and retry an agent after this long with no output. Also a <a href="#knobs">config key</a></td></tr>
               <tr><td>--hard-timeout=&lt;d&gt;</td><td>20m</td><td class="prose">kill an agent after this long, per attempt. Also a config key</td></tr>
               <tr><td>--stagger-delay=&lt;d&gt;</td><td>30s</td><td class="prose">how long to wait for the first agent before releasing the rest. Also a config key</td></tr>


### PR DESCRIPTION
## Problem

revmux runs the finders with the review worktree as cwd. Claude Code resolves `.mcp.json` by walking up the ancestor directories, so a worktree inside a repo that defines project MCP servers boots the whole roster in every finder, every round.

Measured on one monorepo: 161 tools where a strict run has 31. One of those servers is an `mcp-remote` bridge to Atlassian whose OAuth was never completed, so every spawn opened a browser consent tab — a three-repo, three-round review left about nine to close by hand.

A finder reads a diff and returns findings. None of that roster is work it can use.

## Why not configuration

Checked first, per CONTRIBUTING:

- `revmux --help` exposes nothing that reaches the child argv.
- `revmux config` shows the profile schema carries `executor`, `model` and `effort` per roster entry, nothing else.
- On the Claude Code side, `/mcp` disable toggles live in `~/.claude.json` keyed by exact cwd, so they never apply to a fresh worktree, and `enableAllProjectMcpServers: false` in project settings is inert for any other cwd (tested).

What I ran before this patch: a PATH shim dir ahead of revmux, holding a fake `claude` that re-execs the real one with `--strict-mcp-config`. Works, but every caller inside a repo with project MCP servers has to reinvent it.

## Change

`args()` already carries a curated set — `--permission-mode auto`, `--disallowedTools Edit,Write`, `--disable-slash-commands`, `--no-session-persistence`. `--strict-mcp-config` joins it. With no `--mcp-config` passed that leaves zero servers, and unlike `--bare` it keeps project-instruction discovery, so the rule against `--bare` is untouched.

`--preserve-mcp` is the escape hatch, shaped after `--preserve-anthropic-api-key`: a bool on `Opts`, set once in `executorOpts`, rather than on `Request`, which is per roster entry.

Docs updated: README, both site pages, both plugin skill trees, `.claude/rules/executor.md`.

## Codex left alone

No CLI arg turns codex MCP servers off. `-c 'mcp_servers={}'` merges instead of replacing — measured, and filed upstream as openai/codex#16045, still open. A non-map value is rejected (`invalid type: integer 0, expected a map`). The only per-invocation route is one `-c mcp_servers.<name>.enabled=false` per server, which needs `codex mcp list --json` read first. `CODEX_HOME` pointed at an empty config does return zero servers, but it moves `auth.json` and the session rollouts `app/executor/rollout.go` tails.

## Tests

`make lint` and `make check-plugins` clean. `make test` passes except `TestCodex_Run_rolloutLivenessIsNotTheDisplayFilter`, which also fails on unmodified master here (macOS 15.6, go1.26.5), so it is not from this change.

## Process

CONTRIBUTING asks a first-time contributor to open an issue and wait for approval. Going straight to the PR was deliberate: the diff is 44 lines and reads faster than the issue describing it. Say the word and I will close this and file the issue instead.
