### PR TITLE
Package the Codex skill for marketplace install

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "revmux",
+  "interface": {
+    "displayName": "Revmux"
+  },
+  "plugins": [
+    {
+      "name": "revmux",
+      "source": {
+        "source": "local",
+        "path": "./plugins/codex"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/.github/scripts/validate-codex-marketplace.py
+++ b/.github/scripts/validate-codex-marketplace.py
@@ -8,24 +8,12 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 MARKETPLACE = ROOT / ".agents" / "plugins" / "marketplace.json"
 PLUGIN_ROOT = ROOT / "plugins" / "codex"
-EXPECTED_FILES = {
-    ".codex-plugin/plugin.json",
+# entry files nothing else checks: the manifest and SKILL.md fail their own reads above, and
+# `make check-plugins` diffs references/ and scripts/ against the Claude tree
+ENTRY_FILES = (
     "README.md",
-    "skills/revmux/SKILL.md",
     "skills/revmux/agents/openai.yaml",
-    "skills/revmux/references/invocation.md",
-    "skills/revmux/references/loop.md",
-    "skills/revmux/references/output.md",
-    "skills/revmux/references/pr.md",
-    "skills/revmux/references/present.md",
-    "skills/revmux/references/task-dir.md",
-    "skills/revmux/references/triage.md",
-    "skills/revmux/scripts/agentdeck-window.sh",
-    "skills/revmux/scripts/analyze-corpus.py",
-    "skills/revmux/scripts/launch-revmux.sh",
-    "skills/revmux/scripts/preflight.sh",
-    "skills/revmux/scripts/task-state.sh",
-}
+)
 
 
 def load_json(path: Path) -> dict:
@@ -74,14 +62,8 @@ def main() -> None:
         "Codex skill hard-codes the legacy direct-install path"
     )
 
-    packaged_files = {
-        str(path.relative_to(PLUGIN_ROOT))
-        for path in PLUGIN_ROOT.rglob("*")
-        if path.is_file()
-    }
-    assert packaged_files == EXPECTED_FILES, (
-        f"unexpected Codex payload: {sorted(packaged_files ^ EXPECTED_FILES)}"
-    )
+    for relative in ENTRY_FILES:
+        assert (PLUGIN_ROOT / relative).is_file(), f"Codex payload is missing {relative}"
 
     print("Codex marketplace manifest is valid")
 

--- a/.github/scripts/validate-codex-marketplace.py
+++ b/.github/scripts/validate-codex-marketplace.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Validate the Codex marketplace and its local plugin manifest."""
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MARKETPLACE = ROOT / ".agents" / "plugins" / "marketplace.json"
+PLUGIN_ROOT = ROOT / "plugins" / "codex"
+EXPECTED_FILES = {
+    ".codex-plugin/plugin.json",
+    "README.md",
+    "skills/revmux/SKILL.md",
+    "skills/revmux/agents/openai.yaml",
+    "skills/revmux/references/invocation.md",
+    "skills/revmux/references/loop.md",
+    "skills/revmux/references/output.md",
+    "skills/revmux/references/pr.md",
+    "skills/revmux/references/present.md",
+    "skills/revmux/references/task-dir.md",
+    "skills/revmux/references/triage.md",
+    "skills/revmux/scripts/agentdeck-window.sh",
+    "skills/revmux/scripts/analyze-corpus.py",
+    "skills/revmux/scripts/launch-revmux.sh",
+    "skills/revmux/scripts/preflight.sh",
+    "skills/revmux/scripts/task-state.sh",
+}
+
+
+def load_json(path: Path) -> dict:
+    with path.open(encoding="utf-8") as stream:
+        return json.load(stream)
+
+
+def main() -> None:
+    if not __debug__:
+        raise RuntimeError("assertions must be enabled for marketplace validation")
+
+    marketplace = load_json(MARKETPLACE)
+    assert marketplace["name"] == "revmux"
+    assert marketplace["interface"]["displayName"] == "Revmux"
+    assert len(marketplace["plugins"]) == 1, "unexpected Codex plugin count"
+
+    plugin = marketplace["plugins"][0]
+    assert set(plugin) == {"name", "source", "policy", "category"}
+    assert plugin["name"] == "revmux"
+    assert plugin["source"] == {
+        "source": "local",
+        "path": "./plugins/codex",
+    }
+    assert plugin["policy"] == {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL",
+    }
+    assert plugin["category"] == "Developer Tools"
+
+    resolved_root = (ROOT / plugin["source"]["path"]).resolve()
+    assert resolved_root == PLUGIN_ROOT.resolve(), "Codex source points outside its plugin root"
+
+    manifest = load_json(PLUGIN_ROOT / ".codex-plugin" / "plugin.json")
+    claude_manifest = load_json(ROOT / ".claude-plugin" / "plugin.json")
+    assert manifest["name"] == plugin["name"]
+    assert manifest["version"] == claude_manifest["version"], (
+        "Codex and Claude plugin versions differ"
+    )
+    assert manifest["skills"] == "./skills/"
+    assert manifest["interface"]["category"] == plugin["category"]
+
+    skill_text = (PLUGIN_ROOT / "skills" / "revmux" / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    assert "~/.codex/skills/revmux" not in skill_text, (
+        "Codex skill hard-codes the legacy direct-install path"
+    )
+
+    packaged_files = {
+        str(path.relative_to(PLUGIN_ROOT))
+        for path in PLUGIN_ROOT.rglob("*")
+        if path.is_file()
+    }
+    assert packaged_files == EXPECTED_FILES, (
+        f"unexpected Codex payload: {sorted(packaged_files ^ EXPECTED_FILES)}"
+    )
+
+    print("Codex marketplace manifest is valid")
+
+
+if __name__ == "__main__":
+    main()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,8 @@ If a note would be equally true of any Go project, it does not belong here.
 - `app/*/mocks/` — moq-generated, never edited by hand
 
 `.claude-plugin/` and `plugins/codex/` ship the **caller** as a skill, one tree per harness.
+`.claude-plugin/marketplace.json` publishes the Claude Code package; `.agents/plugins/marketplace.json`
+publishes the Codex package from `plugins/codex/`, whose `.codex-plugin/plugin.json` declares its skill tree.
 They contain no Go and are not built; they are documentation plus four shell scripts.
 The two trees carry duplicate copies of `references/` and `scripts/` on purpose — a plugin has to be
 self-contained once installed, so a shared directory is not available to them.

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ lint-scripts:
 # plugins/codex/ is a hand-maintained copy rather than a link. What must not diverge is the content:
 # an edit to one tree's references/ or scripts/ that never reached the other is a skill that behaves
 # one way under claude and another under codex. The validator also pins the marketplace source, policy,
-# manifest version and complete Codex payload so a partial package cannot pass CI.
+# manifest version and the payload's entry files, which the two diffs above do not cover.
 check-plugins:
 	diff -r .claude-plugin/skills/revmux/references plugins/codex/skills/revmux/references
 	diff -r .claude-plugin/skills/revmux/scripts plugins/codex/skills/revmux/scripts

--- a/Makefile
+++ b/Makefile
@@ -54,10 +54,12 @@ lint-scripts:
 # the two skill trees ship to different harnesses and each must be self-contained once installed, so
 # plugins/codex/ is a hand-maintained copy rather than a link. What must not diverge is the content:
 # an edit to one tree's references/ or scripts/ that never reached the other is a skill that behaves
-# one way under claude and another under codex.
+# one way under claude and another under codex. The validator also pins the marketplace source, policy,
+# manifest version and complete Codex payload so a partial package cannot pass CI.
 check-plugins:
 	diff -r .claude-plugin/skills/revmux/references plugins/codex/skills/revmux/references
 	diff -r .claude-plugin/skills/revmux/scripts plugins/codex/skills/revmux/scripts
+	python3 .github/scripts/validate-codex-marketplace.py
 	@echo "plugin trees agree"
 
 fmt:

--- a/README.md
+++ b/README.md
@@ -87,16 +87,21 @@ make install      # and symlinks it to /usr/local/bin/revmux
 the location with `BINDIR` when `/usr/local/bin` is not writable. `make uninstall` removes the link.
 
 **Then install the skill, which is what asks for a review.** The binary runs one; the skill is how your
-coding agent drives it. In Claude Code:
+coding agent drives it:
 
-```
-/plugin marketplace add umputun/revmux
-/plugin install revmux@revmux
+```sh
+# Claude Code
+claude plugin marketplace add umputun/revmux
+claude plugin install revmux@revmux
+
+# Codex
+codex plugin marketplace add umputun/revmux
+codex plugin add revmux@revmux
 ```
 
-For Codex CLI, copy the tree instead: `cp -r plugins/codex/skills/revmux ~/.codex/skills/revmux`. After
-either, ask for a review in words: revmux this branch, revmux pr 123, re-review after fixes. See
-[Agent skills](#agent-skills) for what it does.
+Install the skill through one marketplace only. If you previously copied or symlinked the Codex skill into
+`~/.codex/skills/revmux`, remove that copy after installing the plugin. Then ask for a review in words:
+revmux this branch, revmux pr 123, re-review after fixes. See [Agent skills](#agent-skills) for what it does.
 
 revmux drives the model CLIs as subprocesses, so whichever ones your profile names must already be installed
 and authenticated: both for `comprehensive`, `focused`, `final`, `grill-me`, `triage` and `expert`, claude
@@ -342,8 +347,8 @@ same task after fixes.
 
 | harness | location | install |
 |---|---|---|
-| Claude Code | `.claude-plugin/skills/revmux/` | `/plugin marketplace add umputun/revmux` then `/plugin install revmux@revmux` |
-| Codex CLI | `plugins/codex/skills/revmux/` | `cp -r plugins/codex/skills/revmux ~/.codex/skills/revmux` |
+| Claude Code | `.claude-plugin/skills/revmux/` | `claude plugin marketplace add umputun/revmux` then `claude plugin install revmux@revmux` |
+| Codex CLI | `plugins/codex/skills/revmux/` | `codex plugin marketplace add umputun/revmux` then `codex plugin add revmux@revmux` |
 
 Both carry the same reference material and the same scripts: `preflight.sh` checks the binaries an invocation
 needs, `task-state.sh` reports what a task holds, `launch-revmux.sh` runs revmux with its TUI in a terminal

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,0 +1,39 @@
+{
+  "name": "revmux",
+  "version": "0.4.3",
+  "description": "Run supervised multi-agent code reviews and issue triage from Codex",
+  "author": {
+    "name": "Umputun",
+    "email": "umputun@gmail.com",
+    "url": "https://github.com/umputun"
+  },
+  "homepage": "https://revmux.com",
+  "repository": "https://github.com/umputun/revmux",
+  "license": "MIT",
+  "keywords": [
+    "code-review",
+    "multi-agent",
+    "supervision",
+    "claude",
+    "codex"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Revmux",
+    "shortDescription": "Run supervised multi-agent reviews from Codex",
+    "longDescription": "Run supervised multi-agent code reviews and issue triage from Codex, inspect the resulting findings, apply fixes, and review the next round.",
+    "developerName": "Umputun",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://revmux.com",
+    "defaultPrompt": [
+      "Review this branch with Revmux",
+      "Triage this issue with Revmux",
+      "Run another Revmux round after fixes"
+    ]
+  }
+}

--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -25,24 +25,15 @@ conventions.
 
 ## Install
 
-Clone the repository:
+Add the marketplace and install the plugin:
 
 ```bash
-git clone https://github.com/umputun/revmux.git
-cd revmux
+codex plugin marketplace add umputun/revmux
+codex plugin add revmux@revmux
 ```
 
-Then copy the skill into the Codex skills directory:
-
-```bash
-cp -r plugins/codex/skills/revmux ~/.codex/skills/revmux
-```
-
-Or symlink it, so `git pull` propagates updates without re-copying:
-
-```bash
-ln -s "$PWD/plugins/codex/skills/revmux" ~/.codex/skills/revmux
-```
+If you previously copied or symlinked the skill into `~/.codex/skills/revmux`, remove that copy after
+installing the plugin so the marketplace package is the only one Codex loads.
 
 ## `/revmux`
 
@@ -64,8 +55,8 @@ round on the same task; revmux carries the prior rounds into every prompt itself
 
 ## Differences from the Claude Code plugin
 
-- Script paths resolve from the installed skill under `$CODEX_HOME` (or `~/.codex`), instead of
-  `$CLAUDE_SKILL_DIR`
+- Script paths resolve from the installed skill's absolute path in Codex's available-skills catalogue,
+  instead of `$CLAUDE_SKILL_DIR`
 - `AskUserQuestion` is replaced by numbered-list prompts, the Codex convention
 - `EnterPlanMode` is replaced by an inline markdown plan plus an explicit confirmation before any
   file is modified

--- a/plugins/codex/skills/revmux/SKILL.md
+++ b/plugins/codex/skills/revmux/SKILL.md
@@ -19,14 +19,10 @@ It does no scope detection, no git, no PR fetching, no source modification. This
 
 ## Script path resolution
 
-Resolve `<skill-dir>` from this skill's absolute `SKILL.md` path in the available-skills catalogue, then set:
-
-```bash
-SCRIPT_DIR="<skill-dir>/scripts"
-```
-
-Replace `<skill-dir>` with the resolved absolute path before running a command. Use `$SCRIPT_DIR` for all
-bundled scripts below; marketplace plugins live in a versioned cache, not `~/.codex/skills/`.
+The bundled scripts live in `scripts/` beside this `SKILL.md`. Resolve each one's absolute path from this
+skill's `SKILL.md` entry in the available-skills catalogue, and write that path, in double quotes, in place of
+the `<the absolute path this session resolved for scripts/…>` placeholder wherever a command below carries it.
+Marketplace plugins live in a versioned cache, not `~/.codex/skills/`, so no fixed path can be written here.
 
 | this skill | revmux |
 |---|---|
@@ -101,7 +97,7 @@ the JSON unparseable.
 ### Step 0: Preflight
 
 ```bash
-$SCRIPT_DIR/preflight.sh [profile] [--lenses]
+"<the absolute path this session resolved for scripts/preflight.sh>" [profile] [--lenses]
 ```
 
 Checks revmux plus every binary the invocation needs. Exits `1` naming what is missing.
@@ -208,9 +204,9 @@ Measured over eight archived rounds it ran 65 to 156 seconds, and the wall-clock
 at a flat rate across all eight — so what makes it slow is prose written and turns taken, not tool
 latency. The budgets and the prohibitions in the brief are load-bearing for that, not tidiness.
 
-**Expand every path before handing the brief over.** The subagent does not have this skill loaded, so
-the parent skill directory is not inherited by a subagent, so substitute its resolved absolute path into the brief
-rather than passing the variable through, or its `task-state.sh` step silently runs nothing.
+**Expand every path before handing the brief over.** The subagent does not have this skill loaded and
+cannot resolve the skill directory itself, so substitute the resolved absolute path into the brief's text,
+or its `task-state.sh` step silently runs nothing.
 
 **Say one line first, then spawn it:** `Preparing the round for <what is being reviewed>…` — the
 subject in the user's own terms, "the branch against master", "PR 123", "the last 3 commits". Then
@@ -392,7 +388,7 @@ and the user has no other signal. An overlay run is that signal, on screen, live
 **Overlay — when the user wants to watch:**
 
 ```bash
-$SCRIPT_DIR/launch-revmux.sh --task <id> --run <name> [any revmux flag]
+"<the absolute path this session resolved for scripts/launch-revmux.sh>" --task <id> --run <name> [any revmux flag]
 ```
 
 Detects the terminal (agterm, tmux, zellij, herdr, kitty, wezterm/kaku, cmux, ghostty, iTerm2, Emacs
@@ -646,7 +642,7 @@ rounds produced and proposes changes to the review configuration itself.
 ### Step S1: Run the analysis
 
 ```bash
-$SCRIPT_DIR/analyze-corpus.py
+"<the absolute path this session resolved for scripts/analyze-corpus.py>"
 ```
 
 It walks the archive and prints numbered conclusions with the numbers behind each, then the tables they

--- a/plugins/codex/skills/revmux/SKILL.md
+++ b/plugins/codex/skills/revmux/SKILL.md
@@ -17,6 +17,17 @@ stalls, retries what hangs, and returns findings on stdout.
 
 It does no scope detection, no git, no PR fetching, no source modification. This skill does that half.
 
+## Script path resolution
+
+Resolve `<skill-dir>` from this skill's absolute `SKILL.md` path in the available-skills catalogue, then set:
+
+```bash
+SCRIPT_DIR="<skill-dir>/scripts"
+```
+
+Replace `<skill-dir>` with the resolved absolute path before running a command. Use `$SCRIPT_DIR` for all
+bundled scripts below; marketplace plugins live in a versioned cache, not `~/.codex/skills/`.
+
 | this skill | revmux |
 |---|---|
 | resolve what is under review | supervise, stagger, retry, degrade |
@@ -90,7 +101,7 @@ the JSON unparseable.
 ### Step 0: Preflight
 
 ```bash
-~/.codex/skills/revmux/scripts/preflight.sh [profile] [--lenses]
+$SCRIPT_DIR/preflight.sh [profile] [--lenses]
 ```
 
 Checks revmux plus every binary the invocation needs. Exits `1` naming what is missing.
@@ -381,7 +392,7 @@ and the user has no other signal. An overlay run is that signal, on screen, live
 **Overlay — when the user wants to watch:**
 
 ```bash
-~/.codex/skills/revmux/scripts/launch-revmux.sh --task <id> --run <name> [any revmux flag]
+$SCRIPT_DIR/launch-revmux.sh --task <id> --run <name> [any revmux flag]
 ```
 
 Detects the terminal (agterm, tmux, zellij, herdr, kitty, wezterm/kaku, cmux, ghostty, iTerm2, Emacs
@@ -635,7 +646,7 @@ rounds produced and proposes changes to the review configuration itself.
 ### Step S1: Run the analysis
 
 ```bash
-~/.codex/skills/revmux/scripts/analyze-corpus.py
+$SCRIPT_DIR/analyze-corpus.py
 ```
 
 It walks the archive and prints numbered conclusions with the numbers behind each, then the tables they


### PR DESCRIPTION
Previously, Codex users had to copy or symlink the maintained skill into `~/.codex/skills/revmux`, while the repository marketplace exposed only the Claude Code package.

After this change, the repository publishes `plugins/codex` as a native Codex plugin, documents marketplace installation for both agents, and resolves the bundled scripts from the installed skill's catalogue path, which works from the versioned plugin cache. CI validates the marketplace metadata, entry-file presence and plugin version parity; the existing diffs keep checking the mirrored `references/` and `scripts/`.

`make test`, `make lint`, `make build` and `make check-plugins` pass. A clean marketplace installation resolved and ran the cached preflight script.

Resolves #18.
