### PR TITLE
fix: wait before an agent's retry so it does not hit the same window

### DIFF
--- a/.claude/rules/pipeline.md
+++ b/.claude/rules/pipeline.md
@@ -136,14 +136,32 @@ The verifier is the authority anyway; dropping is only a cost optimization.
 
 ### Degrade policy
 
-Stall or crash → kill → retry **once** → second failure marks the source `degraded` and the pipeline **continues**.
+Stall or crash → kill → wait → retry **once** → second failure marks the source `degraded` and the pipeline **continues**.
 Never abort the whole run because one agent died — one flaky agent would waste every other agent's work and tokens.
+
+**The wait is what makes the retry a second chance rather than a second copy of the first.**
+`finder.retryPause` sleeps `Config.RetryDelay` plus a jitter of up to that again before relaunching, on the
+Clock, so a transient condition has time to clear and agents that failed together do not relaunch in
+lockstep into the same collision — a colliding `codex exec` launch is the reported instance of both.
+It is one interval and not a curve because `maxAttempts` allows exactly one retry.
+**It runs before `EventAgentRetried` is emitted**, because `app/archive` counts those entries as this
+agent's retries — `SourceStat.Retries`, read from `events.jsonl` and from nowhere else — so a cancellation
+during the wait must degrade the source without recording a retry that never relaunched.
+The delay is injected rather than constant so the retry path is testable without waiting one out, and
+non-positive means relaunch at once — the same convention the stagger reads its timeout under.
+Synthesis retries without one; see below.
 
 **Every source degrading is the one exception.** A run with zero reporting sources has no review to report,
 so it is a tool error and exits `2`, not a clean report with an empty findings list.
 See `.claude/rules/config.md` on exit codes.
 
 **Synthesis retries once and then fails the run — it is the one stage with no degrade path, deliberately.**
+Its relaunch is immediate, and that is a scope decision rather than an impossibility.
+Synthesis can collide the same way: the collision is host-wide — another `codex exec` from any caller,
+a second revmux instance — and `codex-only` runs synthesis on codex like everything else in it.
+What is missing is evidence: the reported failure is the find stage's, where a roster launches together,
+and a wait added to the one call whose second failure exits `2` would be added on a hunch.
+Whether synthesis wants one is its own question, on its own evidence.
 It is a single call standing between every finder's completed work and the report, so `synthesizer.dispatch`
 gives it the same one-launch-plus-one-retry the find stage gives an agent: a transient `529` must not
 discard a find stage that already ran for minutes.

--- a/.claude/rules/pipeline.md
+++ b/.claude/rules/pipeline.md
@@ -145,8 +145,9 @@ Clock, so a transient condition has time to clear and agents that failed togethe
 lockstep into the same collision — a colliding `codex exec` launch is the reported instance of both.
 It is one interval and not a curve because `maxAttempts` allows exactly one retry.
 **It runs before `EventAgentRetried` is emitted**, because `app/archive` counts those entries as this
-agent's retries — `SourceStat.Retries`, read from `events.jsonl` and from nowhere else — so a cancellation
-during the wait must degrade the source without recording a retry that never relaunched.
+agent's retries — `agentStats.Retries` in `app/archive/stats.go`, read from `events.jsonl` and from
+nowhere else, since no stage snapshot records a relaunch — so a cancellation during the wait must degrade
+the source without recording a retry that never relaunched.
 The delay is injected rather than constant so the retry path is testable without waiting one out, and
 non-positive means relaunch at once — the same convention the stagger reads its timeout under.
 Synthesis retries without one; see below.

--- a/app/main.go
+++ b/app/main.go
@@ -32,9 +32,11 @@ const executorCodex = "codex"
 // agentRetryDelay is the floor an agent waits before its one retry, which the pipeline jitters up to
 // twice that. A relaunch in the same millisecond band as the failure meets whatever transient condition
 // killed it — a colliding codex launch is the reported one — and degrades a source a wait of seconds
-// would have kept. It is a constant rather than a flag because there is nothing here to tune: the wait
-// is short beside a review, and only a run already failing ever pays it.
-const agentRetryDelay = 2 * time.Second
+// would have kept. It is sized against that collision rather than against a launch-side fault, which
+// clears in well under a second: the report puts the hazardous window at 10-20s, so the wait errs long,
+// since too short degrades a source silently while too long costs seconds on a run already failing.
+// It is a constant rather than a flag because there is nothing here a caller can calibrate better.
+const agentRetryDelay = 5 * time.Second
 
 // runOpts is what run needs from its surroundings. Every one of them is injected so the whole entry
 // point is drivable from a test: no real terminal, no real clock, no writes to the process streams.

--- a/app/main.go
+++ b/app/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/jessevdk/go-flags"
@@ -28,16 +29,26 @@ var revision = "unknown"
 // executorCodex is the one roster executor that is not claude, which is also the default.
 const executorCodex = "codex"
 
+// agentRetryDelay is the floor an agent waits before its one retry, which the pipeline jitters up to
+// twice that. A relaunch in the same millisecond band as the failure meets whatever transient condition
+// killed it — a colliding codex launch is the reported one — and degrades a source a wait of seconds
+// would have kept. It is a constant rather than a flag because there is nothing here to tune: the wait
+// is short beside a review, and only a run already failing ever pays it.
+const agentRetryDelay = 2 * time.Second
+
 // runOpts is what run needs from its surroundings. Every one of them is injected so the whole entry
 // point is drivable from a test: no real terminal, no real clock, no writes to the process streams.
 type runOpts struct {
-	opts      options
-	clock     executor.Clock
-	stdout    io.Writer
-	stderr    io.Writer
-	openTTY   func() (*os.File, error)
-	newRunner func(pipeline.RunnerSpec) pipeline.Runner
-	snapshot  func(reviewContext) []ui.InputDocument
+	opts  options
+	clock executor.Clock
+	// retryDelay is injected rather than read from agentRetryDelay so a test drives the retry path
+	// without waiting one out; only main supplies the production value.
+	retryDelay time.Duration
+	stdout     io.Writer
+	stderr     io.Writer
+	openTTY    func() (*os.File, error)
+	newRunner  func(pipeline.RunnerSpec) pipeline.Runner
+	snapshot   func(reviewContext) []ui.InputDocument
 }
 
 // configuredReview is everything one review resolved before it starts. Keeping the context beside the
@@ -62,7 +73,7 @@ func main() {
 	}
 
 	os.Exit(run(runOpts{
-		opts: o, clock: executor.NewClock(),
+		opts: o, clock: executor.NewClock(), retryDelay: agentRetryDelay,
 		stdout: os.Stdout, stderr: os.Stderr, openTTY: openTTY,
 	}))
 }
@@ -201,7 +212,7 @@ func (o runOpts) pipelineConfig() (configuredReview, error) {
 		Set:       set, Profile: profile, Roster: roster, Vars: rc.vars(), History: history,
 		Task: o.opts.Task, Run: o.opts.Run, ScopePath: rc.Scope,
 		NoSynthesis: o.opts.NoSynthesis, NoVerify: o.opts.NoVerify,
-		StaggerDelay: o.opts.StaggerDelay, MaxParallel: o.opts.MaxParallel,
+		StaggerDelay: o.opts.StaggerDelay, RetryDelay: o.retryDelay, MaxParallel: o.opts.MaxParallel,
 		VerifyGroups: o.opts.VerifyGroups, VerifyGroupBy: o.opts.VerifyGroupBy,
 	}
 	return configuredReview{pipeline: cfg, archive: arc, context: rc}, nil

--- a/app/main_test.go
+++ b/app/main_test.go
@@ -341,6 +341,16 @@ func TestRun_review(t *testing.T) {
 		assert.Equal(t, "above the bar", rep.Findings[0].Title)
 	})
 
+	t.Run("the retry delay reaches the pipeline", func(t *testing.T) {
+		require.Positive(t, agentRetryDelay, "a zero constant is a retry with no wait at all")
+		ro := newRunOpts(t, base(t)).opts()
+		ro.retryDelay = agentRetryDelay
+
+		review, err := ro.pipelineConfig()
+		require.NoError(t, err)
+		assert.Equal(t, agentRetryDelay, review.pipeline.RetryDelay)
+	})
+
 	t.Run("the verify grouping mode reaches the pipeline", func(t *testing.T) {
 		o := base(t)
 		o.VerifyGroupBy = "source"

--- a/app/pipeline/find.go
+++ b/app/pipeline/find.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/rand/v2"
 	"path"
 	"slices"
 	"strconv"
@@ -85,7 +86,8 @@ func (f *finder) run(ctx context.Context) ([]sourceResult, error) {
 }
 
 // runAgent runs one roster entry, retrying once when the first launch fails in a way a second might
-// survive. A second failure degrades this source alone and the run continues.
+// survive, after a jittered pause so the retry does not land in the same window that killed the launch.
+// A second failure degrades this source alone and the run continues.
 func (f *finder) runAgent(ctx context.Context, spec prompt.AgentSpec, index int) sourceResult {
 	res := sourceResult{spec: spec, stat: finding.SourceStat{
 		Name: spec.Name, Lenses: spec.Lenses, Executor: spec.Executor,
@@ -122,6 +124,11 @@ func (f *finder) runAgent(ctx context.Context, spec prompt.AgentSpec, index int)
 			if ctx.Err() != nil || opts.n == maxAttempts-1 {
 				break
 			}
+			// the wait comes before the event because app/archive counts agent_retried entries as
+			// retries: a cancellation while waiting would otherwise record one that never relaunched
+			if pauseErr := f.retryPause(ctx); pauseErr != nil {
+				break
+			}
 			f.emit(Event{Kind: EventAgentRetried, Agent: spec.Name, Text: fault.Error()})
 			continue
 		}
@@ -135,6 +142,29 @@ func (f *finder) runAgent(ctx context.Context, spec prompt.AgentSpec, index int)
 		return res
 	}
 	return f.degrade(res, fault)
+}
+
+// retryPause waits out Config.RetryDelay before a relaunch, so whatever transient condition killed the
+// launch has time to clear: a retry firing in the same millisecond band reproduces the timing that
+// killed the first attempt. The jitter separates agents that failed together and would otherwise
+// relaunch in lockstep into the same collision. There is no growth factor because maxAttempts allows a
+// single retry, so there is only ever one interval. A non-positive delay relaunches at once, the same
+// convention the stagger reads a non-positive timeout under.
+func (f *finder) retryPause(ctx context.Context) error {
+	d := f.cfg.RetryDelay
+	if d <= 0 {
+		return nil
+	}
+	done := make(chan struct{})
+	//nolint:gosec // the jitter separates colliding relaunches, it guards nothing
+	timer := f.cfg.Clock.AfterFunc(d+rand.N(d), func() { close(done) })
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		timer.Stop()
+		return fmt.Errorf("wait before retry: %w", ctx.Err())
+	}
 }
 
 // attempt runs one process under its own cancellable context, so a retry tears the stalled attempt's

--- a/app/pipeline/find_test.go
+++ b/app/pipeline/find_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/umputun/revmux/app/executor"
+	emocks "github.com/umputun/revmux/app/executor/mocks"
 	"github.com/umputun/revmux/app/finding"
 	"github.com/umputun/revmux/app/pipeline/mocks"
 	"github.com/umputun/revmux/app/prompt"
@@ -453,6 +454,123 @@ func TestFinder_retry(t *testing.T) {
 		res := f.runAgent(ctx, h.cfg.Roster[0], 0)
 		require.False(t, res.ok())
 		assert.Equal(t, int64(1), attempts.Load(), "retrying into a canceled context buys nothing")
+	})
+}
+
+func TestFinder_retryPause(t *testing.T) {
+	// a failing first attempt and a delivering second, so every case here reaches the pause
+	retryThenDeliver := func(attempts *atomic.Int64) func(RunnerSpec) Runner {
+		return func(RunnerSpec) Runner {
+			return &mocks.RunnerMock{RunFunc: func(context.Context, executor.Request, executor.EventSink) (executor.Result, error) {
+				if attempts.Add(1) == 1 {
+					return executor.Result{ExitCode: 1}, nil
+				}
+				return executor.Result{StructuredOutput: findingsJSON(
+					`{"file":"a.go","line":1,"severity":"major","confidence":85,"title":"survived"}`)}, nil
+			}}
+		}
+	}
+
+	t.Run("the retry waits out the delay before it relaunches", func(t *testing.T) {
+		h := newHarness(t)
+		var attempts atomic.Int64
+		h.cfg.NewRunner = retryThenDeliver(&attempts)
+		h.cfg.RetryDelay = 2 * time.Second
+
+		var armed []time.Duration
+		var waited atomic.Int64
+		h.cfg.Clock = &emocks.ClockMock{
+			NowFunc: func() time.Time { return time.Date(2026, 7, 26, 16, 2, 11, 0, time.UTC) },
+			AfterFuncFunc: func(d time.Duration, fire func()) executor.Timer {
+				armed = append(armed, d)
+				waited.Store(attempts.Load())
+				fire()
+				return &emocks.TimerMock{StopFunc: func() bool { return true }, ResetFunc: func(time.Duration) bool { return true }}
+			},
+		}
+
+		var kinds []EventKind
+		f := h.finder(func(ev Event) { kinds = append(kinds, ev.Kind) })
+		res := f.runAgent(context.Background(), h.cfg.Roster[0], 0)
+		require.True(t, res.ok())
+		assert.Equal(t, int64(2), attempts.Load())
+		assert.Equal(t, int64(1), waited.Load(), "the wait falls between the two launches")
+		require.Len(t, armed, 1, "one retry, one wait")
+		assert.GreaterOrEqual(t, armed[0], h.cfg.RetryDelay, "the configured delay is the floor")
+		assert.Less(t, armed[0], 2*h.cfg.RetryDelay, "and the jitter adds at most another of it")
+		assert.Equal(t, []EventKind{EventAgentStarted, EventAgentRetried, EventFindings, EventAgentDone}, kinds)
+	})
+
+	t.Run("jitter separates agents that failed together", func(t *testing.T) {
+		h := newHarness(t)
+		h.cfg.RetryDelay = time.Second
+		f := h.finder(func(Event) {})
+
+		seen := map[time.Duration]bool{}
+		for range 50 {
+			var d time.Duration
+			f.cfg.Clock = &emocks.ClockMock{
+				AfterFuncFunc: func(got time.Duration, fire func()) executor.Timer {
+					d = got
+					fire()
+					return &emocks.TimerMock{StopFunc: func() bool { return true }, ResetFunc: func(time.Duration) bool { return true }}
+				},
+			}
+			require.NoError(t, f.retryPause(context.Background()))
+			seen[d] = true
+		}
+		assert.Greater(t, len(seen), 1, "a fixed delay would relaunch every agent into the same window")
+	})
+
+	t.Run("a non-positive delay relaunches without arming anything", func(t *testing.T) {
+		h := newHarness(t)
+		var attempts atomic.Int64
+		h.cfg.NewRunner = retryThenDeliver(&attempts)
+
+		clk := &emocks.ClockMock{
+			NowFunc: func() time.Time { return time.Date(2026, 7, 26, 16, 2, 11, 0, time.UTC) },
+			AfterFuncFunc: func(time.Duration, func()) executor.Timer {
+				return &emocks.TimerMock{StopFunc: func() bool { return true }, ResetFunc: func(time.Duration) bool { return true }}
+			},
+		}
+		h.cfg.Clock = clk
+
+		f := h.finder(func(Event) {})
+		res := f.runAgent(context.Background(), h.cfg.Roster[0], 0)
+		require.True(t, res.ok())
+		assert.Equal(t, int64(2), attempts.Load())
+		assert.Empty(t, clk.AfterFuncCalls(), "nothing to wait on, so nothing armed")
+	})
+
+	t.Run("a cancellation while waiting stops the retry and reports none", func(t *testing.T) {
+		h := newHarness(t)
+		var attempts atomic.Int64
+		h.cfg.NewRunner = retryThenDeliver(&attempts)
+		h.cfg.RetryDelay = time.Hour
+
+		ctx, cancel := context.WithCancel(context.Background())
+		var stopped atomic.Int64
+		h.cfg.Clock = &emocks.ClockMock{
+			NowFunc: func() time.Time { return time.Date(2026, 7, 26, 16, 2, 11, 0, time.UTC) },
+			AfterFuncFunc: func(time.Duration, func()) executor.Timer {
+				cancel() // the wait is armed, so this is the run being torn down mid-pause
+				return &emocks.TimerMock{
+					StopFunc:  func() bool { stopped.Add(1); return true },
+					ResetFunc: func(time.Duration) bool { return true },
+				}
+			},
+		}
+
+		var kinds []EventKind
+		f := h.finder(func(ev Event) { kinds = append(kinds, ev.Kind) })
+		res := f.runAgent(ctx, h.cfg.Roster[0], 0)
+		cancel()
+		require.False(t, res.ok(), "the first attempt's fault is what degraded the source")
+		require.ErrorContains(t, res.err, "exited 1")
+		assert.Equal(t, int64(1), attempts.Load(), "the second launch never happened")
+		assert.Equal(t, int64(1), stopped.Load(), "the abandoned timer is stopped")
+		assert.Equal(t, []EventKind{EventAgentStarted, EventAgentDegraded}, kinds,
+			"app/archive counts agent_retried entries as retries, so one that never relaunched must not be recorded")
 	})
 }
 

--- a/app/pipeline/find_test.go
+++ b/app/pipeline/find_test.go
@@ -501,7 +501,9 @@ func TestFinder_retryPause(t *testing.T) {
 		assert.Equal(t, []EventKind{EventAgentStarted, EventAgentRetried, EventFindings, EventAgentDone}, kinds)
 	})
 
-	t.Run("jitter separates agents that failed together", func(t *testing.T) {
+	// one draw cannot tell [d, 2d) from a bound that is wrong half the time, so both the spread and the
+	// bounds are asserted over samples
+	t.Run("every draw lands in the band and the draws differ", func(t *testing.T) {
 		h := newHarness(t)
 		h.cfg.RetryDelay = time.Second
 		f := h.finder(func(Event) {})
@@ -517,6 +519,8 @@ func TestFinder_retryPause(t *testing.T) {
 				},
 			}
 			require.NoError(t, f.retryPause(context.Background()))
+			require.GreaterOrEqual(t, d, h.cfg.RetryDelay, "the configured delay is the floor of every draw")
+			require.Less(t, d, 2*h.cfg.RetryDelay, "and the jitter adds at most another of it")
 			seen[d] = true
 		}
 		assert.Greater(t, len(seen), 1, "a fixed delay would relaunch every agent into the same window")

--- a/app/pipeline/pipeline.go
+++ b/app/pipeline/pipeline.go
@@ -100,6 +100,7 @@ type Config struct {
 	NoVerify    bool
 
 	StaggerDelay  time.Duration
+	RetryDelay    time.Duration // waited out before an agent's one retry, jittered; non-positive relaunches at once
 	MaxParallel   int
 	VerifyGroups  int
 	VerifyGroupBy string // "dir", the default, or "source" to key verifier groups by the agent that raised the finding

--- a/site/docs.html
+++ b/site/docs.html
@@ -319,7 +319,8 @@ revmux --task pr-123 --run 02-after-fix &gt; findings.json</pre>
         <h2 id="supervision">Supervision and degrade <a class="anchor" href="#supervision">#</a></h2>
         <p>
           A <strong>finder</strong> that produces no output for <code>--idle-timeout</code> (2m by default) is
-          killed and retried once. So is one that exceeds <code>--hard-timeout</code> (20m per attempt). On a
+          killed and retried once, after a short jittered pause so the relaunch does not land in whatever
+          window killed it. So is one that exceeds <code>--hard-timeout</code> (20m per attempt). On a
           second failure the agent is marked degraded and the run continues: the report banner names the
           missing agent, and synthesis is told the real source count rather than being left to assume a full
           roster. A run where every source degraded is a tool error, not a clean empty report.


### PR DESCRIPTION
A failed agent launch was relaunched with no delay, so whatever transient condition killed the first attempt killed the retry too and the source degraded. Reported in #20: another `codex exec` starting on the same host within seconds of revmux's own codex agent kills it, and the retry firing in the same millisecond band dies the same way. A `comprehensive` or `final` round then reports on its claude agents alone.

`finder.retryPause` waits before relaunching: a 5s floor plus a jitter of up to 5s more. The jitter is there for the second half of the same problem, agents that failed together would otherwise relaunch in lockstep into the same collision. One interval and no growth factor, since `maxAttempts` allows exactly one retry.

**The wait runs before `EventAgentRetried` is emitted.** `app/archive` reads those entries as that agent's retry count and no stage snapshot records a relaunch, so a cancellation during the wait has to degrade the source without writing a retry that never happened.

The delay reaches the pipeline as `pipeline.Config.RetryDelay`, fed from a private `runOpts.retryDelay` that only `main` fills from the `agentRetryDelay` constant. No flag and no config key: 5s is sized against the 10-20s window #20 measures the hazard over, and erring long is the cheap direction, too short degrades a source silently while too long costs a few seconds on a run that was already failing. Tests get zero and skip the wait, the same convention `--stagger-delay` already reads a non-positive value under.

**What is deliberately not here**

- synthesis still retries immediately. It can collide the same way, `codex-only` runs it on codex and the collision is host-wide, but the reported failure is the find stage's and a wait on the one call whose second failure exits `2` would be guesswork. `.claude/rules/pipeline.md` says so, otherwise the omission reads later as an oversight.
- no per-host launch lock and no flag to tune the delay, both asked for in #20. The first is a new coordination mechanism, the second is a knob with nothing behind it a caller can calibrate better.
- not `go-pkgz/repeater/v2`, which owns the whole loop while the sleep is the only part missing. The loop carries the attempt number out to the tee filename, bills tokens from the failed attempt too, emits the retry event between attempts, and decides retryability from `executor.Result` fields rather than from an error. Repeater also sleeps on real time, and the wait has to go on the injected `executor.Clock` or the retry tests wait for real.

Related to #20
