### PR TITLE
fix(skill): forward CLAUDE_CONFIG_DIR to the overlay child

### DIFF
--- a/.claude-plugin/skills/revmux/references/invocation.md
+++ b/.claude-plugin/skills/revmux/references/invocation.md
@@ -147,8 +147,8 @@ revmux spawns `claude` and `codex` itself, and overlay backends start children f
 whose environment predates the user's shell rc files. Without forwarding, every agent degrades on a
 binary that is plainly installed and the run exits `2`.
 
-`HOME`, `XDG_CONFIG_HOME`, `CODEX_HOME` and `TMPDIR` are forwarded for the same reason — they decide
-where the CLIs and revmux look for configuration and auth.
+`HOME`, `XDG_CONFIG_HOME`, `CLAUDE_CONFIG_DIR`, `CODEX_HOME` and `TMPDIR` are forwarded for the same
+reason — they decide where the CLIs and revmux look for configuration and auth.
 
 `ANTHROPIC_API_KEY` is **not** forwarded. An `env KEY=VAL` prefix places the value in the process
 argv, where any `ps` on the machine can read it. revmux strips that variable from its children by

--- a/.claude-plugin/skills/revmux/scripts/launch-revmux.sh
+++ b/.claude-plugin/skills/revmux/scripts/launch-revmux.sh
@@ -103,7 +103,7 @@ fi
 # process argv where any `ps` can read it. revmux strips that variable from its children by default
 # anyway, so overlay runs use interactive subscription auth. Use headless mode for key-based auth.
 ENV_PREFIX=" $(sq "PATH=$PATH")"
-for _name in HOME XDG_CONFIG_HOME CODEX_HOME TMPDIR; do
+for _name in HOME XDG_CONFIG_HOME CLAUDE_CONFIG_DIR CODEX_HOME TMPDIR; do
     if [ "${!_name+x}" = x ]; then
         ENV_PREFIX="$ENV_PREFIX $(sq "${_name}=${!_name}")"
     fi

--- a/plugins/codex/skills/revmux/references/invocation.md
+++ b/plugins/codex/skills/revmux/references/invocation.md
@@ -147,8 +147,8 @@ revmux spawns `claude` and `codex` itself, and overlay backends start children f
 whose environment predates the user's shell rc files. Without forwarding, every agent degrades on a
 binary that is plainly installed and the run exits `2`.
 
-`HOME`, `XDG_CONFIG_HOME`, `CODEX_HOME` and `TMPDIR` are forwarded for the same reason — they decide
-where the CLIs and revmux look for configuration and auth.
+`HOME`, `XDG_CONFIG_HOME`, `CLAUDE_CONFIG_DIR`, `CODEX_HOME` and `TMPDIR` are forwarded for the same
+reason — they decide where the CLIs and revmux look for configuration and auth.
 
 `ANTHROPIC_API_KEY` is **not** forwarded. An `env KEY=VAL` prefix places the value in the process
 argv, where any `ps` on the machine can read it. revmux strips that variable from its children by

--- a/plugins/codex/skills/revmux/scripts/launch-revmux.sh
+++ b/plugins/codex/skills/revmux/scripts/launch-revmux.sh
@@ -103,7 +103,7 @@ fi
 # process argv where any `ps` can read it. revmux strips that variable from its children by default
 # anyway, so overlay runs use interactive subscription auth. Use headless mode for key-based auth.
 ENV_PREFIX=" $(sq "PATH=$PATH")"
-for _name in HOME XDG_CONFIG_HOME CODEX_HOME TMPDIR; do
+for _name in HOME XDG_CONFIG_HOME CLAUDE_CONFIG_DIR CODEX_HOME TMPDIR; do
     if [ "${!_name+x}" = x ]; then
         ENV_PREFIX="$ENV_PREFIX $(sq "${_name}=${!_name}")"
     fi


### PR DESCRIPTION
`launch-revmux.sh` overlays a fixed set of caller values onto the overlay child's environment, and `CLAUDE_CONFIG_DIR` was not among them.

that matters because overlay backends start the child from a server or app process that never sourced the user's shell config, so the env prefix the launcher builds is the only route a value like this has. Claude normally finds its config through `HOME`, which is forwarded, but setting `CLAUDE_CONFIG_DIR` moves the config and the variable becomes the only pointer to it. The child then looks in the wrong place, every claude agent fails to authenticate, and the run degrades to the codex peer alone. `CODEX_HOME` was already forwarded, so codex agents were fine either way.

the fix adds the one name, in both shipped skill trees plus the sentence in `references/invocation.md` that lists the forwarded set:

```sh
-for _name in HOME XDG_CONFIG_HOME CODEX_HOME TMPDIR; do
+for _name in HOME XDG_CONFIG_HOME CLAUDE_CONFIG_DIR CODEX_HOME TMPDIR; do
```

the loop is guarded by a set-test, so with the variable unset the generated prefix is byte-identical to before. I exercised that block directly with the variable set to a value containing a space: it comes through correctly quoted.

no broader change to what gets forwarded. The prefix overlays rather than replaces, so the list is the set of caller values that must beat a stale server environment, and widening it would put more values into the generated argv for no defect anyone has hit.

reported and diagnosed by @vistrcm, including the exact diff.

Related to #22
