### PR TITLE
trim reviewer context, and give the loop an exit for an excluded scope

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "revmux",
       "source": "./",
       "description": "Run a supervised multi-agent code review or triage a filed issue with parallel claude and codex subprocesses, and act on what comes back",
-      "version": "0.4.3",
+      "version": "0.5.0",
       "author": {
         "name": "umputun"
       }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "revmux",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "Run a supervised multi-agent code review or triage a filed issue with parallel claude and codex subprocesses, and act on what comes back",
   "author": {
     "name": "umputun",

--- a/.claude-plugin/skills/revmux/SKILL.md
+++ b/.claude-plugin/skills/revmux/SKILL.md
@@ -515,7 +515,8 @@ skips `minor`" is not answered by adding one more case to the switch.
 Then run the tests and the linter. A fix that breaks the build is not committed.
 3. Open the next round on the same task and write its own `scope` — the fixes and the range they land
    in. **That is Step 2's subagent again**, with the same one-line announcement, the task id it
-   already returned and a fresh `--shortstat` for the fixes, so a re-review costs the session no more
+   already returned, every exclusion the earlier rounds carried, and a fresh `--shortstat` for the
+   fixes, so a re-review costs the session no more
    output than the first round did — and the brief's step 2 is skipped outright, since the id is not in
    question on a round of a task that already has rounds. Then run it:
 

--- a/.claude-plugin/skills/revmux/SKILL.md
+++ b/.claude-plugin/skills/revmux/SKILL.md
@@ -207,6 +207,8 @@ Spawn **one** `general-purpose` agent. Hand it the resolved scope from Step 1 an
 >
 > The scope is: `<the row resolved in Step 1, with its ref range>`, and its scale is
 > `<the shortstat Step 1 printed>`. Take the scale as given rather than measuring it again.
+> Exclusions the user has stated: `<list them, or "none">` — write these under the scope's
+> explicit exclusions. They are decisions already taken, and the diff cannot show you one.
 >
 > 1. Read the change: the diff for that range, once, and the file list. That is the whole of the
 >    exploration. Do not read source files in full, do not grep the tree, and do not run a further diff

--- a/.claude-plugin/skills/revmux/references/loop.md
+++ b/.claude-plugin/skills/revmux/references/loop.md
@@ -23,6 +23,13 @@ Gating is `critical` and `major` in `findings`. Nothing else:
 - `minor` never gates — it is what the loop is expected to leave behind.
 - `immaterial`, `pre_existing` and `open_questions` are not in `findings` and never gate. An open
   question is a decision for the user, so the loop must not edit code to resolve one.
+- **A finding restating a scope the round's own `scope.md` or `goal.md` puts outside the change does not
+  gate.** The loop cannot overturn that decision by editing code, so the same finding returns unchanged
+  on every round and no confirming round can ever clear it. Report it in full and treat the round as
+  clean on it. **The exclusion has to be written in the round's input**, not recalled from the
+  conversation: keyed on memory this becomes "he ruled that out" for any inconvenient major, which is
+  silent suppression wearing the exemption's clothes. Written down, each round's brief carries it and
+  the finding usually stops recurring at the source.
 - A `degraded` run gates nothing either way: it is not evidence. Stop and report it.
 
 **A round in which you fixed something is never a clean exit.** Clean means a *review* came back with
@@ -45,7 +52,8 @@ zero gating findings. After fixing, always run the confirming round.
 3. Commit locally. **Never push** — that stays the user's decision, and it is what makes the whole loop
    revertible.
 4. Open the next round and run it. Its `scope` is the cumulative diff from the starting commit, not just
-   this round's fixes.
+   this round's fixes, and it repeats every exclusion the earlier rounds carried — a round that drops one
+   is a round the excluded finding gates again.
 
 Profile per round follows Step 7: `final` when the fixes stayed inside what the last round flagged,
 `comprehensive` when they spilled into tests or structure.
@@ -103,8 +111,14 @@ worded — because the fix did not answer it and the next one will not either. N
 cap.** Say so in the round report — "round 3: 2 gating again, both new, continuing" — or the user reads a
 flat number as a stall. The five-round cap is the bound on that case and it does not need a second one.
 
-On a clean exit with minors left, ask **once** whether to sweep them. Fix them if so and stop either
-way — no review round runs after that question.
+On a clean exit with findings left, ask **once** what to do with them, as a single question offering
+three courses: fix the shortlist, fix every minor, or leave them all. **The shortlist goes inside the
+question**, not only in the report above it — at most five, ranked, each with its mechanism and what
+leaving it costs, since that is what he decides against. Fix what he picks and stop either way; no
+review round runs after that question.
+
+The shortlist is what the option buys. Offered only a blanket sweep, an unranked pile of minors gets
+taken or dropped wholesale, and the two or three that were worth the round go either way with the rest.
 
 ## While it runs
 

--- a/.claude-plugin/skills/revmux/references/task-dir.md
+++ b/.claude-plugin/skills/revmux/references/task-dir.md
@@ -71,7 +71,8 @@ What is being reviewed, and how to get at it. Not intent — that is `goal.md`.
 2. **The commands to see it** — revmux runs no git; agents run these themselves
 3. **Scale** — so the reviewer can trade breadth against depth
 4. **Which files to read in full**, and why each matters
-5. **Explicit exclusions** — vendored code, generated files
+5. **Explicit exclusions** — vendored code, generated files, and any approach the user has already
+   ruled out, so a review does not keep re-proposing what he decided against
 
 ````markdown
 # Scope

--- a/.claude/rules/executor.md
+++ b/.claude/rules/executor.md
@@ -59,7 +59,9 @@ Measured directly against the real CLI. Do not re-derive, and do not assume any 
 claude --print --output-format stream-json --verbose
        --model <m> --effort <e>
        --permission-mode auto
-       --disallowedTools "Edit,Write"
+       --tools=Bash,Read,Grep,Glob,WebFetch,WebSearch
+       --strict-mcp-config
+       --setting-sources project
        --disable-slash-commands
        --no-session-persistence
        --include-partial-messages
@@ -74,10 +76,41 @@ claude --print --output-format stream-json --verbose
   themselves. The agent does not fail: it says "Bash is denied in this mode" and reads files instead,
   so a diff-scoped review silently becomes a whole-tree review with the delta guessed. Measured
   directly: `dontAsk` with no allowlist denies, `auto` allows.
-- `--disallowedTools` removes the edit tools from the agent's context — revmux never modifies source.
+- **The three context-trimming flags exist to cut what a reviewer carries before it reads anything**,
+  and they reach only this child — a developer's own interactive claude session is untouched.
+  `--tools` filters the built-in tool set down to the six a reviewer uses.
+  `--strict-mcp-config` with **no** `--mcp-config` drops every MCP server the user configured, along
+  with the connect time each agent spent on them; no shipped prompt names an MCP tool.
+  `--setting-sources project` drops the user and local `settings.json` layers.
+  **How much each saves is a property of the config, not of the flag**, so do not carry a per-flag
+  breakdown here — on a config with no MCP servers the middle one saves nothing at all.
+  One headline number, reproducible: 54,814 prompt tokens to 38,322 on the revmux tree, this machine's
+  config, claude 2.1.260, 2026-09-04.
+  **`--setting-sources` does less than its name suggests**: it selects `settings.json` layers, and a
+  `CLAUDE.md` is a memory file rather than a setting, so the agent still loads both the project and the
+  user one. That is most of what remains after the trim.
+  **`--tools` is variadic, so it must be passed as one argv element.** `--tools A,B` followed by a
+  positional swallows the positional; revmux sends the prompt on stdin, so nothing is exposed today,
+  and the `=` form is what keeps it that way. `--setting-sources` takes a single value and needs none.
+  **The floor this sets is claude 2.1.162.** Below it, `Grep` and `Glob` named in `--tools` are silently
+  ignored on native builds, so a reviewer runs without them and nothing reports it. An unrecognised flag
+  is the loud case instead — exit 1 before any model call, which degrades through the normal path.
+- **`--setting-sources project` also decides what the child stops inheriting, and that is the part someone
+  debugging a reviewer needs.** The user layer carries `model`, `effortLevel`, `env`, `sandbox`,
+  `permissions`, `hooks` and `enabledPlugins`, and none of them reach the agent now.
+  A roster entry with a bare `claude` runner therefore gets the CLI's own default model and effort
+  rather than the user's saved ones. Every shipped profile names both explicitly, so shipped reviews are
+  unaffected, and `manifest.json` records requested against actual either way.
+  Model alias remaps set in the user layer's `env` — `ANTHROPIC_DEFAULT_SONNET_MODEL` and its siblings —
+  stop reaching the child too, so `claude/sonnet` in a user roster resolves to the CLI's sonnet. A shell
+  export still reaches it, since that is the process environment rather than a settings layer.
+- The allowlist is what removes the edit tools from the agent's context — revmux never modifies source —
+  and it removes `Task`, so a reviewer cannot fan out into subagents of its own.
+  There is no `--disallowedTools`: naming `Edit,Write` in a denylist beside an allowlist that omits them
+  states the same thing twice.
   This is best-effort, not a sandbox; the prompt must state the constraint too, and every shipped
   profile and stage prompt does.
-  **Keep this list to the edit tools. Do not grow it into a Bash denylist.**
+  **Do not add a `--disallowedTools` Bash denylist beside the allowlist.**
   `auto` was measured allowing `echo ... > main.go` and `rm -f main.go` to delete a tracked file, so
   the exposure is real — but a shell can write through a redirect, which is syntax rather than a
   command and cannot be denied by name at all, so a Bash denylist buys a fraction of a guarantee while

--- a/.claude/rules/executor.md
+++ b/.claude/rules/executor.md
@@ -101,9 +101,18 @@ claude --print --output-format stream-json --verbose
   A roster entry with a bare `claude` runner therefore gets the CLI's own default model and effort
   rather than the user's saved ones. Every shipped profile names both explicitly, so shipped reviews are
   unaffected, and `manifest.json` records requested against actual either way.
-  Model alias remaps set in the user layer's `env` — `ANTHROPIC_DEFAULT_SONNET_MODEL` and its siblings —
-  stop reaching the child too, so `claude/sonnet` in a user roster resolves to the CLI's sonnet. A shell
-  export still reaches it, since that is the process environment rather than a settings layer.
+  **`env` is the exception, and which way it falls depends on how revmux was launched.** The flag drops
+  the user layer's `env` *block*, but a variable already in revmux's own process environment is
+  inherited: `proc.childEnv` passes everything through but `CLAUDECODE` and `ANTHROPIC_API_KEY`, and
+  `--setting-sources` selects settings layers rather than the environment. So a model alias remap like
+  `ANTHROPIC_DEFAULT_SONNET_MODEL` still reaches the child on the **headless** path, where a Claude Code
+  session has already promoted its own settings `env` into the environment revmux inherits — measured on
+  this machine. On the **overlay** path it does not: `launch-revmux.sh` runs revmux under `/usr/bin/env`
+  with an explicit variable list, from a backend whose environment predates the user's shell.
+  A maintainer reading an unexpected `actual_model` in `manifest.json` needs that split; the flag alone
+  does not explain it.
+  **`apiKeyHelper` has no such route** — it is a settings key rather than a variable, so the user layer's
+  copy is dropped on both paths. A setup whose headless authentication lives only there loses it.
 - The allowlist is what removes the edit tools from the agent's context — revmux never modifies source —
   and it removes `Task`, so a reviewer cannot fan out into subagents of its own.
   There is no `--disallowedTools`: naming `Edit,Write` in a denylist beside an allowlist that omits them

--- a/.claude/rules/executor.md
+++ b/.claude/rules/executor.md
@@ -103,8 +103,9 @@ claude --print --output-format stream-json --verbose
   unaffected, and `manifest.json` records requested against actual either way.
   **`env` is the exception, and which way it falls depends on how revmux was launched.** The flag drops
   the user layer's `env` *block*, but a variable already in revmux's own process environment is
-  inherited: `proc.childEnv` passes everything through but `CLAUDECODE` and `ANTHROPIC_API_KEY`, and
-  `--setting-sources` selects settings layers rather than the environment. So a model alias remap like
+  inherited: `proc.childEnv` passes everything through but `CLAUDECODE` and, unless
+  `--preserve-anthropic-api-key` is set, `ANTHROPIC_API_KEY`; `--setting-sources` selects settings
+  layers rather than the environment. So a model alias remap like
   `ANTHROPIC_DEFAULT_SONNET_MODEL` still reaches the child on the **headless** path, where a Claude Code
   session has already promoted its own settings `env` into the environment revmux inherits — measured on
   this machine. On the **overlay** path it does not: `launch-revmux.sh` runs revmux under `/usr/bin/env`

--- a/.revmux/profile.md
+++ b/.revmux/profile.md
@@ -1,0 +1,103 @@
+# Project profile — revmux
+
+## What this is
+
+A standalone Go CLI, personal tooling, one maintainer. It spawns and supervises parallel `claude
+--print` and `codex exec` subprocesses, merges what they report, and returns findings as JSON on
+stdout. No server, no network service, no daemon, no user data, no persistence beyond the run
+archive under `.revmux/tasks/`.
+
+It is driven by a caller model rather than typed by a person, so its output shape and its
+configuration are machine-readable by design.
+
+## What a real failure looks like
+
+Concrete, in rough order of how much it costs:
+
+- **A review that silently reviews the wrong thing** — the wrong scope, a prompt composed from the
+  wrong precedence layer, a stage resolved to a runner the manifest does not record.
+- **An archive that cannot reconstruct the run** — a composed prompt not written, a stage snapshot
+  missing, a manifest naming a model that did not run. The archive exists so a later reflection
+  agent can ask which lens text raised a finding; one that cannot answer that is broken even when
+  the review it recorded was fine.
+- **Attribution that inflates confidence** — `sources` carrying anything but distinct agent names,
+  or one agent counted twice. The cross-source boost is the whole reason two executors run.
+- **Supervision that does not supervise** — a stalled agent the watchdog misses, a retry that lands
+  in the same rate-limit window, a kill that leaves a child alive.
+- **Anything but the report on stdout** — a status line, a warning or a banner there makes
+  `revmux > findings.json` unparseable, which is the primary way it is used.
+- **Documentation that states a flag, exit code, JSON field or archive path the binary does not
+  have** — `site/`, `README.md` and both skill trees are executed by agents without checking.
+
+## Blast radius
+
+One maintainer, one machine. A crash costs one review, which is re-run. Nothing here is a security
+boundary in the usual sense and no untrusted input reaches it, except a `.revmux/` checked into a
+repository under review — which is executable configuration and is treated as such in the skill,
+not in the binary.
+
+What actually costs is a wrong review believed, or an archive that cannot be audited afterwards.
+Weigh findings against those two, not against uptime.
+
+## Where the project's rules live
+
+`CLAUDE.md` at the repo root is the authority, and `.claude/rules/*.md` carry the per-subsystem
+detail — `executor.md`, `pipeline.md`, `prompts.md`, `tui.md`, `config.md`, `testing.md`, each
+scoped by `paths:` front matter. `CLAUDE.md` also holds a long keep-in-sync list naming every place
+a flag, profile, lens, roster key or schema change must land.
+
+**A deviation from a documented rule there is always worth reporting**, including a change that
+lands in one of the keep-in-sync sites and not the others.
+
+## The reporting bar
+
+Findings must be material, not merely true.
+
+Noise here:
+
+- **Anything the linter or the tests catch.** `golangci-lint` runs 45+ linters including `revive`,
+  `gocritic`, `gosec`, `wrapcheck` and `exhaustive`; tests run under `-race` at ~94% coverage. Both
+  ran and passed before this review.
+- **Style, naming and idiom preferences**, and "consider extracting this".
+- **Duplication listed as deliberate below.**
+- **"Add more tests"** as a bare suggestion. A new branch with no case pinning it is a finding; a
+  coverage number is not.
+
+Real here:
+
+- A contradiction or a stale fact in `.claude/rules/`, `CLAUDE.md`, `site/` or either skill tree.
+  Those are contracts a machine executes against, so a wrong statement is a defect rather than a
+  wording nit. A wording *preference* in the same files is still noise.
+- A change that makes a round un-auditable, or that widens the one carve-out in the
+  archive-write-fails-the-run rule.
+
+## Conventions that are deliberate — do not file these as defects
+
+- **Zero VCS dependency.** No git library, no `git` subprocess, no repo walking anywhere in the
+  binary. Agents run diff commands themselves; revmux substitutes a path. "Why not use go-git" is
+  the rule, not an oversight.
+- **Context variables expand to paths, never to file content.** Prompt composition stats the
+  caller's files and never opens one.
+- **The two skill trees carry byte-identical `references/` and `scripts/`.** `.claude-plugin/` and
+  `plugins/codex/` duplicate on purpose — a plugin must be self-contained once installed. Only
+  `SKILL.md` differs. A `diff -r` of the other two directories coming back empty is the invariant.
+- **The severity bar and the "what not to report" block are duplicated byte-identical across
+  shipped profiles.** Nothing composes them from one place, deliberately; three profiles carry
+  their own variant because their review shape needs a different bar.
+- **`app/archive` spells stage names and event kinds as string literals** rather than importing
+  `app/pipeline`, to keep the artifact package free of the orchestrator. Same for `manifest.json`'s
+  `finished_at`, decoded through a local partial struct.
+- **`--permission-mode auto` with no Bash denylist.** Measured: `dontAsk` denies the `git diff` the
+  whole design depends on. A `Bash(sed:*)` denial was tried and reverted. The read-only guarantee
+  rests on the prompt, not on flags.
+- **Everything private by default** — functions, methods, types and fields alike. Exported only for
+  an out-of-package caller.
+- **Mocks are moq-generated under `mocks/` and never hand-edited.**
+- **One test file per source file**, `foo.go` → `foo_test.go`, never a third.
+
+## Languages in play
+
+Go is the binary. Markdown under `.claude/rules/`, `app/prompt/defaults/` and both skill trees is
+instructions a model executes, so judge it as a contract rather than as prose. Shell scripts are
+shellcheck-gated in CI where any output at all fails the job, including info-level findings. One
+Python script under each skill tree aggregates the archive and has its own tests.

--- a/app/executor/claude.go
+++ b/app/executor/claude.go
@@ -59,7 +59,13 @@ func ClaudeNarrationContract(schema json.RawMessage) string {
 		"- One line at a time, under a dozen words, and never a summary of what you already said.\n"
 }
 
-// args builds the invocation. --include-partial-messages is there for the idle watchdog rather than for
+// args builds the invocation. The three context-trimming flags — the --tools allowlist,
+// --strict-mcp-config with no --mcp-config, and --setting-sources project — cut what a reviewer
+// carries before it reads anything, and they reach only this child. --tools is variadic, so it must
+// be one argv element or a later positional is swallowed; it also drops Edit and Write, which is why
+// no --disallowedTools follows, and Task, so a reviewer cannot fan out into subagents of its own.
+// The numbers and what the child stops inheriting are in .claude/rules/executor.md.
+// --include-partial-messages is there for the idle watchdog rather than for
 // anything revmux decodes: without it the whole StructuredOutput tool call arrives as one line written
 // after it is complete, so a large answer puts the stream past the idle timeout with the agent working —
 // measured killing synthesis twice at 120s while it merged 39 findings. The deltas are the only liveness
@@ -70,7 +76,9 @@ func (c *Claude) args(req Request) []string {
 		"--output-format", "stream-json",
 		"--verbose",
 		"--permission-mode", "auto",
-		"--disallowedTools", "Edit,Write",
+		"--tools=Bash,Read,Grep,Glob,WebFetch,WebSearch",
+		"--strict-mcp-config",
+		"--setting-sources", "project",
 		"--disable-slash-commands",
 		"--no-session-persistence",
 		"--include-partial-messages",

--- a/app/executor/claude_test.go
+++ b/app/executor/claude_test.go
@@ -102,7 +102,9 @@ func TestClaude_args(t *testing.T) {
 	want := []string{
 		"--print", "--output-format", "stream-json", "--verbose",
 		"--permission-mode", "auto",
-		"--disallowedTools", "Edit,Write",
+		"--tools=Bash,Read,Grep,Glob,WebFetch,WebSearch",
+		"--strict-mcp-config",
+		"--setting-sources", "project",
 		"--disable-slash-commands",
 		"--no-session-persistence",
 		"--include-partial-messages",
@@ -112,6 +114,8 @@ func TestClaude_args(t *testing.T) {
 	}
 	assert.Equal(t, want, call.Args)
 	assert.NotContains(t, call.Args, "--bare", "--bare forces api-key auth and drops project instructions")
+	assert.NotContains(t, call.Args, "--tools", "--tools is variadic and must stay one argv element")
+	assert.NotContains(t, call.Args, "--mcp-config", "--strict-mcp-config with no --mcp-config is what drops every server")
 }
 
 func TestClaude_args_optionalFlagsOmitted(t *testing.T) {
@@ -129,6 +133,10 @@ func TestClaude_args_optionalFlagsOmitted(t *testing.T) {
 	assert.Contains(t, args, "--disable-slash-commands")
 	assert.Contains(t, args, "--include-partial-messages",
 		"the watchdog's only liveness while the model composes a large StructuredOutput call")
+	assert.Contains(t, args, "--tools=Bash,Read,Grep,Glob,WebFetch,WebSearch",
+		"the allowlist is what removes Edit, Write and Task from the agent's context")
+	assert.Contains(t, args, "--strict-mcp-config")
+	assert.NotContains(t, args, "--disallowedTools", "the allowlist already excludes the edit tools")
 }
 
 func TestClaude_Run_clean(t *testing.T) {

--- a/plugins/codex/skills/revmux/SKILL.md
+++ b/plugins/codex/skills/revmux/SKILL.md
@@ -213,6 +213,8 @@ Hand it the resolved scope from Step 1 and this brief:
 >
 > The scope is: `<the row resolved in Step 1, with its ref range>`, and its scale is
 > `<the shortstat Step 1 printed>`. Take the scale as given rather than measuring it again.
+> Exclusions the user has stated: `<list them, or "none">` — write these under the scope's
+> explicit exclusions. They are decisions already taken, and the diff cannot show you one.
 >
 > 1. Read the change: the diff for that range, once, and the file list. That is the whole of the
 >    exploration. Do not read source files in full, do not grep the tree, and do not run a further diff

--- a/plugins/codex/skills/revmux/SKILL.md
+++ b/plugins/codex/skills/revmux/SKILL.md
@@ -522,7 +522,8 @@ skips `minor`" is not answered by adding one more case to the switch.
 Then run the tests and the linter. A fix that breaks the build is not committed.
 3. Open the next round on the same task and write its own `scope` — the fixes and the range they land
    in. **That is Step 2's subagent again**, with the same one-line announcement, the task id it
-   already returned and a fresh `--shortstat` for the fixes, so a re-review costs the session no more
+   already returned, every exclusion the earlier rounds carried, and a fresh `--shortstat` for the
+   fixes, so a re-review costs the session no more
    output than the first round did — and the brief's step 2 is skipped outright, since the id is not in
    question on a round of a task that already has rounds. Then run it:
 

--- a/plugins/codex/skills/revmux/references/loop.md
+++ b/plugins/codex/skills/revmux/references/loop.md
@@ -23,6 +23,13 @@ Gating is `critical` and `major` in `findings`. Nothing else:
 - `minor` never gates — it is what the loop is expected to leave behind.
 - `immaterial`, `pre_existing` and `open_questions` are not in `findings` and never gate. An open
   question is a decision for the user, so the loop must not edit code to resolve one.
+- **A finding restating a scope the round's own `scope.md` or `goal.md` puts outside the change does not
+  gate.** The loop cannot overturn that decision by editing code, so the same finding returns unchanged
+  on every round and no confirming round can ever clear it. Report it in full and treat the round as
+  clean on it. **The exclusion has to be written in the round's input**, not recalled from the
+  conversation: keyed on memory this becomes "he ruled that out" for any inconvenient major, which is
+  silent suppression wearing the exemption's clothes. Written down, each round's brief carries it and
+  the finding usually stops recurring at the source.
 - A `degraded` run gates nothing either way: it is not evidence. Stop and report it.
 
 **A round in which you fixed something is never a clean exit.** Clean means a *review* came back with
@@ -45,7 +52,8 @@ zero gating findings. After fixing, always run the confirming round.
 3. Commit locally. **Never push** — that stays the user's decision, and it is what makes the whole loop
    revertible.
 4. Open the next round and run it. Its `scope` is the cumulative diff from the starting commit, not just
-   this round's fixes.
+   this round's fixes, and it repeats every exclusion the earlier rounds carried — a round that drops one
+   is a round the excluded finding gates again.
 
 Profile per round follows Step 7: `final` when the fixes stayed inside what the last round flagged,
 `comprehensive` when they spilled into tests or structure.
@@ -103,8 +111,14 @@ worded — because the fix did not answer it and the next one will not either. N
 cap.** Say so in the round report — "round 3: 2 gating again, both new, continuing" — or the user reads a
 flat number as a stall. The five-round cap is the bound on that case and it does not need a second one.
 
-On a clean exit with minors left, ask **once** whether to sweep them. Fix them if so and stop either
-way — no review round runs after that question.
+On a clean exit with findings left, ask **once** what to do with them, as a single question offering
+three courses: fix the shortlist, fix every minor, or leave them all. **The shortlist goes inside the
+question**, not only in the report above it — at most five, ranked, each with its mechanism and what
+leaving it costs, since that is what he decides against. Fix what he picks and stop either way; no
+review round runs after that question.
+
+The shortlist is what the option buys. Offered only a blanket sweep, an unranked pile of minors gets
+taken or dropped wholesale, and the two or three that were worth the round go either way with the rest.
 
 ## While it runs
 

--- a/plugins/codex/skills/revmux/references/task-dir.md
+++ b/plugins/codex/skills/revmux/references/task-dir.md
@@ -71,7 +71,8 @@ What is being reviewed, and how to get at it. Not intent — that is `goal.md`.
 2. **The commands to see it** — revmux runs no git; agents run these themselves
 3. **Scale** — so the reviewer can trade breadth against depth
 4. **Which files to read in full**, and why each matters
-5. **Explicit exclusions** — vendored code, generated files
+5. **Explicit exclusions** — vendored code, generated files, and any approach the user has already
+   ruled out, so a review does not keep re-proposing what he decided against
 
 ````markdown
 # Scope


### PR DESCRIPTION
two things, both from the same session.

**reviewer context**

revmux now passes three flags to every claude reviewer it spawns: `--tools=Bash,Read,Grep,Glob,WebFetch,WebSearch`, `--strict-mcp-config` with no `--mcp-config`, and `--setting-sources project`. Cuts a reviewer's prompt from 54,814 to 38,322 tokens on this tree, claude 2.1.260. They reach only the spawned child, so an interactive session is untouched.

the allowlist also removes `Task`, so a reviewer cannot fan out into subagents of its own, and it makes `--disallowedTools Edit,Write` redundant.

two things to know about `--setting-sources project`. It drops the user settings layer, so a hand-written roster with a bare `claude` runner now gets the CLI's own default model and effort rather than the saved ones, and an `apiKeyHelper` living only there is dropped too. It does not drop either `CLAUDE.md`, which is a memory file rather than a setting.

below claude 2.1.162, `Grep` and `Glob` named in `--tools` are silently ignored on native builds, so that is the floor. Stated in `.claude/rules/executor.md`, not checked at runtime: an unknown flag fails loudly instead, exit 1 before any model call.

**loop exit**

the loop runs until a review returns no critical or major finding. A major restating a scope the user already ruled out could never clear it: the loop cannot overturn that decision by editing code, so the finding came back unchanged on every round and only the five-round cap ended the run.

such a finding no longer gates, but only when the exclusion is written in the round's own `scope.md` or `goal.md`. Keyed on the loop agent's memory it would become "he ruled that out" for any inconvenient major.

three edits make that anchor reachable. The `scope.md` contract listed only vendored and generated files under explicit exclusions, so a ruled-out approach had nowhere to be written. The Step 2 subagent brief got only a ref range and a shortstat, and is told the diff is the whole of its exploration, so a decision stated in conversation could never reach `scope.md`. And a later round rewrites its scope from the cumulative diff, so step 4 repeats every exclusion the earlier rounds carried.

the clean exit also becomes one question with three courses: fix the ranked shortlist, fix every minor, or leave them all.

both skill trees carry byte-identical `references/` and `scripts/`, so each edit is made twice. Plugin version 0.4.3 to 0.5.0.

**review**

run through revmux `comprehensive` over the finished branch: 4 sources, none degraded, 3 minors, no criticals or majors. Two of the three are fixed in 3rd commit, the `env` inheritance claim in `executor.md` was wrong on the headless path and Step 7's handoff list did not carry exclusions forward.
